### PR TITLE
Fixed 66 prefix jmp/call wrong disasm and added AMD disasm mode

### DIFF
--- a/arch/X86/X86Disassembler.c
+++ b/arch/X86/X86Disassembler.c
@@ -93,7 +93,7 @@ static bool translateSrcIndex(MCInst *mcInst, InternalInstruction *insn)
 {
 	unsigned baseRegNo;
 
-	if (insn->mode == MODE_64BIT)
+	if (insn->mode & MODE_64BIT)
 		baseRegNo = insn->isPrefix67 ? X86_ESI : X86_RSI;
 	else if (insn->mode == MODE_32BIT)
 		baseRegNo = insn->isPrefix67 ? X86_SI : X86_ESI;
@@ -117,7 +117,7 @@ static bool translateDstIndex(MCInst *mcInst, InternalInstruction *insn)
 {
 	unsigned baseRegNo;
 
-	if (insn->mode == MODE_64BIT)
+	if (insn->mode & MODE_64BIT)
 		baseRegNo = insn->isPrefix67 ? X86_EDI : X86_RDI;
 	else if (insn->mode == MODE_32BIT)
 		baseRegNo = insn->isPrefix67 ? X86_DI : X86_EDI;
@@ -471,7 +471,7 @@ static bool translateRMMemory(MCInst *mcInst, InternalInstruction *insn)
 					//debug("EA_BASE_NONE and EA_DISP_NONE for ModR/M base");
 					return true;
 				}
-				if (insn->mode == MODE_64BIT) {
+				if (insn->mode & MODE_64BIT) {
 					if (insn->prefix3 == 0x67)	// address-size prefix overrides RIP relative addressing
 						MCOperand_CreateReg0(mcInst, X86_EIP);
 					else
@@ -824,7 +824,7 @@ bool X86_getInstruction(csh ud, const uint8_t *code, size_t code_len,
 		ret = decodeInstruction(&insn,
 				reader, &info,
 				address,
-				MODE_64BIT);
+				(handle->mode == CS_MODE_64_AMD) ? MODE_64BIT_AMD : MODE_64BIT);
 
 	if (ret) {
 		*size = (uint16_t)(insn.readerCursor - address);

--- a/arch/X86/X86DisassemblerDecoder.c
+++ b/arch/X86/X86DisassemblerDecoder.c
@@ -484,7 +484,7 @@ static int readPrefixes(struct InternalInstruction *insn)
 	bool hasOpSize = false;
 
 	while (isPrefix) {
-		if (insn->mode == MODE_64BIT) {
+		if (insn->mode & MODE_64BIT) {
 			// eliminate consecutive redundant REX bytes in front
 			if (consumeByte(insn, &byte))
 				return -1;
@@ -558,7 +558,7 @@ static int readPrefixes(struct InternalInstruction *insn)
 					 nextByte == 0xc6 || nextByte == 0xc7))
 				insn->xAcquireRelease = true;
 
-			if (insn->mode == MODE_64BIT && (nextByte & 0xf0) == 0x40) {
+			if (insn->mode & MODE_64BIT && (nextByte & 0xf0) == 0x40) {
 				if (consumeByte(insn, &nextByte))
 					return -1;
 				if (lookAtByte(insn, &nextByte))
@@ -674,6 +674,12 @@ static int readPrefixes(struct InternalInstruction *insn)
 		//if (isPrefix)
 		//	dbgprintf(insn, "Found prefix 0x%hhx", byte);
 	}
+	
+	if(insn->mode == MODE_64BIT && (byte == 0xE9 || byte == 0xE8)){
+		hasOpSize = false;
+		insn->prefix2 = 0;
+		insn->isPrefix66 = false;
+	}
 
 	insn->vectorExtensionType = TYPE_NO_VEX_XOP;
 
@@ -686,7 +692,7 @@ static int readPrefixes(struct InternalInstruction *insn)
 			return -1;
 		}
 
-		if ((insn->mode == MODE_64BIT || (byte1 & 0xc0) == 0xc0) &&
+		if ((insn->mode & MODE_64BIT || (byte1 & 0xc0) == 0xc0) &&
 				((~byte1 & 0xc) == 0xc)) {
 			if (lookAtByte(insn, &byte2)) {
 				//dbgprintf(insn, "Couldn't read third byte of EVEX prefix");
@@ -716,7 +722,7 @@ static int readPrefixes(struct InternalInstruction *insn)
 				}
 
 				/* We simulate the REX prefix for simplicity's sake */
-				if (insn->mode == MODE_64BIT) {
+				if (insn->mode & MODE_64BIT) {
 					insn->rexPrefix = 0x40
 						| (wFromEVEX3of4(insn->vectorExtensionPrefix[2]) << 3)
 						| (rFromEVEX2of4(insn->vectorExtensionPrefix[1]) << 2)
@@ -741,7 +747,7 @@ static int readPrefixes(struct InternalInstruction *insn)
 			return -1;
 		}
 
-		if (insn->mode == MODE_64BIT || (byte1 & 0xc0) == 0xc0) {
+		if (insn->mode & MODE_64BIT || (byte1 & 0xc0) == 0xc0) {
 			insn->vectorExtensionType = TYPE_VEX_3B;
 			insn->necessaryPrefixLocation = insn->readerCursor - 1;
 		} else {
@@ -757,7 +763,7 @@ static int readPrefixes(struct InternalInstruction *insn)
 				return -1;
 
 			/* We simulate the REX prefix for simplicity's sake */
-			if (insn->mode == MODE_64BIT) {
+			if (insn->mode & MODE_64BIT) {
 				insn->rexPrefix = 0x40
 					| (wFromVEX3of3(insn->vectorExtensionPrefix[2]) << 3)
 					| (rFromVEX2of3(insn->vectorExtensionPrefix[1]) << 2)
@@ -774,7 +780,7 @@ static int readPrefixes(struct InternalInstruction *insn)
 			return -1;
 		}
 
-		if (insn->mode == MODE_64BIT || (byte1 & 0xc0) == 0xc0) {
+		if (insn->mode & MODE_64BIT || (byte1 & 0xc0) == 0xc0) {
 			insn->vectorExtensionType = TYPE_VEX_2B;
 		} else {
 			unconsumeByte(insn);
@@ -785,7 +791,7 @@ static int readPrefixes(struct InternalInstruction *insn)
 			if (consumeByte(insn, &insn->vectorExtensionPrefix[1]))
 				return -1;
 
-			if (insn->mode == MODE_64BIT) {
+			if (insn->mode & MODE_64BIT) {
 				insn->rexPrefix = 0x40
 					| (rFromVEX2of2(insn->vectorExtensionPrefix[1]) << 2);
 			}
@@ -822,7 +828,7 @@ static int readPrefixes(struct InternalInstruction *insn)
 				return -1;
 
 			/* We simulate the REX prefix for simplicity's sake */
-			if (insn->mode == MODE_64BIT) {
+			if (insn->mode & MODE_64BIT) {
 				insn->rexPrefix = 0x40
 					| (wFromXOP3of3(insn->vectorExtensionPrefix[2]) << 3)
 					| (rFromXOP2of3(insn->vectorExtensionPrefix[1]) << 2)
@@ -839,7 +845,7 @@ static int readPrefixes(struct InternalInstruction *insn)
 			}
 		}
 	} else {
-		if (insn->mode == MODE_64BIT) {
+		if (insn->mode & MODE_64BIT) {
 			if ((byte & 0xf0) == 0x40) {
 				uint8_t opcodeByte;
 
@@ -879,7 +885,7 @@ static int readPrefixes(struct InternalInstruction *insn)
 		insn->displacementSize   = (hasAdSize ? 2 : 4);
 		insn->immediateSize      = (hasOpSize ? 2 : 4);
 		insn->immSize = (hasOpSize ? 2 : 4);
-	} else if (insn->mode == MODE_64BIT) {
+	} else if (insn->mode & MODE_64BIT) {
 		if (insn->rexPrefix && wFromREX(insn->rexPrefix)) {
 			insn->registerSize       = 8;
 			insn->addressSize        = (hasAdSize ? 4 : 8);
@@ -1156,7 +1162,7 @@ static int getID(struct InternalInstruction *insn)
 	// printf(">>> getID()\n");
 	attrMask = ATTR_NONE;
 
-	if (insn->mode == MODE_64BIT)
+	if (insn->mode & MODE_64BIT)
 		attrMask |= ATTR_64BIT;
 
 	if (insn->vectorExtensionType != TYPE_NO_VEX_XOP) {
@@ -1250,17 +1256,7 @@ static int getID(struct InternalInstruction *insn)
 
 	if (getIDWithAttrMask(&instructionID, insn, attrMask))
 		return -1;
-
-	/* Fixing CALL and JMP instruction when in 64bit mode and x66 prefix is used */
-	if (insn->mode == MODE_64BIT && insn->isPrefix66 &&
-	   (insn->opcode == 0xE8 || insn->opcode == 0xE9))
-	{
-		attrMask ^= ATTR_OPSIZE;
-		if (getIDWithAttrMask(&instructionID, insn, attrMask))
-			return -1;
-	}
-
-
+	
 	/*
 	 * JCXZ/JECXZ need special handling for 16-bit mode because the meaning
 	 * of the AdSize prefix is inverted w.r.t. 32-bit mode.
@@ -1969,7 +1965,7 @@ static int readVVVV(struct InternalInstruction *insn)
 	else
 		return -1;
 
-	if (insn->mode != MODE_64BIT)
+	if (!(insn->mode & MODE_64BIT))
 		vvvv &= 0x7;
 
 	insn->vvvv = vvvv;

--- a/arch/X86/X86DisassemblerDecoderCommon.h
+++ b/arch/X86/X86DisassemblerDecoderCommon.h
@@ -532,7 +532,8 @@ typedef enum {
 typedef enum {
 	MODE_16BIT,
 	MODE_32BIT,
-	MODE_64BIT
+	MODE_64BIT,
+	MODE_64BIT_AMD = (MODE_64BIT << 1) | MODE_64BIT
 } DisassemblerMode;
 
 #endif

--- a/arch/X86/X86Module.c
+++ b/arch/X86/X86Module.c
@@ -14,7 +14,7 @@ static cs_err init(cs_struct *ud)
 	MCRegisterInfo *mri;
 
 	// verify if requested mode is valid
-	if (ud->mode & ~(CS_MODE_LITTLE_ENDIAN | CS_MODE_32 | CS_MODE_64 | CS_MODE_16))
+	if (ud->mode & ~(CS_MODE_LITTLE_ENDIAN | CS_MODE_32 | CS_MODE_64 | CS_MODE_64_AMD | CS_MODE_16))
 		return CS_ERR_MODE;
 
 	mri = cs_mem_malloc(sizeof(*mri));
@@ -32,7 +32,7 @@ static cs_err init(cs_struct *ud)
 	ud->group_name = X86_group_name;
 	ud->post_printer = NULL;;
 
-	if (ud->mode == CS_MODE_64)
+	if (ud->mode == CS_MODE_64 || ud->mode == CS_MODE_64_AMD)
 		ud->regsize_map = regsize_map_64;
 	else
 		ud->regsize_map = regsize_map_32;

--- a/include/capstone.h
+++ b/include/capstone.h
@@ -97,6 +97,8 @@ typedef enum cs_mode {
 	CS_MODE_16 = 1 << 1,	// 16-bit mode (X86)
 	CS_MODE_32 = 1 << 2,	// 32-bit mode (X86)
 	CS_MODE_64 = 1 << 3,	// 64-bit mode (X86, PPC)
+	CS_MODE_64_INTEL = CS_MODE_64,// default 64-bit mode (X86)
+	CS_MODE_64_AMD = 1 << 4 || 1<<3, // necassary for 66 jmp/call dissassembly
 	CS_MODE_THUMB = 1 << 4,	// ARM's Thumb mode, including Thumb-2
 	CS_MODE_MCLASS = 1 << 5,	// ARM's Cortex-M series
 	CS_MODE_V8 = 1 << 6,	// ARMv8 A32 encodings for ARM

--- a/include/capstone.h
+++ b/include/capstone.h
@@ -98,7 +98,7 @@ typedef enum cs_mode {
 	CS_MODE_32 = 1 << 2,	// 32-bit mode (X86)
 	CS_MODE_64 = 1 << 3,	// 64-bit mode (X86, PPC)
 	CS_MODE_64_INTEL = CS_MODE_64,// default 64-bit mode (X86)
-	CS_MODE_64_AMD = 1 << 4 || 1<<3, // necassary for 66 jmp/call dissassembly
+	CS_MODE_64_AMD = CS_MODE_64 | (CS_MODE_64 << 1), // necassary for 66 jmp/call dissassembly
 	CS_MODE_THUMB = 1 << 4,	// ARM's Thumb mode, including Thumb-2
 	CS_MODE_MCLASS = 1 << 5,	// ARM's Cortex-M series
 	CS_MODE_V8 = 1 << 6,	// ARMv8 A32 encodings for ARM


### PR DESCRIPTION
Improved version of https://github.com/aquynh/capstone/pull/777


[According to Christopher Domas ](https://youtu.be/KrksBdWcZgQ?t=32m49s)( @xoreaxeaxeax ) the AMD processors are the only that correctly decodes the instruction. Because of that i decided to add a new mode CS_MODE_64_AMD. The only difference to CS_MODE_64 is that it doesn't ignore the operand size(what occurs on Intel processors).