### PR TITLE
Py bindings: use pkg_resources to set package version

### DIFF
--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -73,7 +73,7 @@ TESTS += test_ppc.py test_sparc.py test_systemz.py test_x86.py test_xcore.py tes
 TESTS += test_m680x.py test_skipdata.py test_mos65xx.py
 
 check:
-	python setup.py install
+	python setup.py install --user
 	@for t in $(TESTS); do \
 		echo Check $$t ... ; \
 		./$$t > /dev/null; \

--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -73,6 +73,7 @@ TESTS += test_ppc.py test_sparc.py test_systemz.py test_x86.py test_xcore.py tes
 TESTS += test_m680x.py test_skipdata.py test_mos65xx.py
 
 check:
+	python setup.py install
 	@for t in $(TESTS); do \
 		echo Check $$t ... ; \
 		./$$t > /dev/null; \

--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -1,5 +1,5 @@
 # Capstone Python bindings, by Nguyen Anh Quynnh <aquynh@gmail.com>
-import os, sys
+import os, sys, pkg_resources
 from platform import system
 _python2 = sys.version_info[0] < 3
 if _python2:
@@ -133,11 +133,9 @@ CS_API_MAJOR = 5
 CS_API_MINOR = 0
 
 # Package version
-CS_VERSION_MAJOR = CS_API_MAJOR
-CS_VERSION_MINOR = CS_API_MINOR
-CS_VERSION_EXTRA = 0
+__version__ = pkg_resources.get_distribution("capstone").version
 
-__version__ = "%u.%u.%u" %(CS_VERSION_MAJOR, CS_VERSION_MINOR, CS_VERSION_EXTRA)
+CS_VERSION_MAJOR, CS_VERSION_MINOR, CS_VERSION_EXTRA = __version__.split('.')
 
 # architectures
 CS_ARCH_ARM = 0

--- a/bindings/python/capstone/__init__.py
+++ b/bindings/python/capstone/__init__.py
@@ -128,14 +128,14 @@ __all__ = [
 
 # Capstone C interface
 
-# API version
-CS_API_MAJOR = 5
-CS_API_MINOR = 0
-
 # Package version
 __version__ = pkg_resources.get_distribution("capstone").version
 
 CS_VERSION_MAJOR, CS_VERSION_MINOR, CS_VERSION_EXTRA = __version__.split('.')
+
+# API version
+CS_API_MAJOR = CS_VERSION_MAJOR
+CS_API_MINOR = CS_VERSION_MINOR
 
 # architectures
 CS_ARCH_ARM = 0


### PR DESCRIPTION
This was inspired by the fact we forgot to set the package version when
Capstone 4.0.1 was released: https://github.com/aquynh/capstone/issues/1315#issuecomment-454386418

...now we won't need to set the Python bindings version manually :).