### PR TITLE
arm: simplify DecodeGPRPairRegisterClass()

### DIFF
--- a/arch/ARM/ARMDisassembler.c
+++ b/arch/ARM/ARMDisassembler.c
@@ -971,7 +971,7 @@ static DecodeStatus DecodeGPRPairRegisterClass(MCInst *Inst, unsigned RegNo,
 	if (RegNo > 13)
 		return MCDisassembler_Fail;
 
-	if ((RegNo & 1) || RegNo == 0xe)
+	if (RegNo & 1)
 		S = MCDisassembler_SoftFail;
 
 	RegisterPair = GPRPairDecoderTable[RegNo/2];


### PR DESCRIPTION
For RegNo > 13 we return. After the return statement RegNo cannot be 0x0e.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>