### PR TITLE
Fixed a small typo `Mac OSX`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Capstone offers some unparalleled features:
   Ruby, C#, NodeJS, Java, GO, C++, OCaml, Lua, Rust, Delphi, Free Pascal & Vala
   (ready either in main code, or provided externally by the community).
 
-- Native support for all popular platforms: Windows, Mac OSX, iOS, Android,
+- Native support for all popular platforms: Windows, macOS, iOS, Android,
   Linux, \*BSD, Solaris, etc.
 
 - Thread-safe by design.


### PR DESCRIPTION
This corrected a small typo in the README.md