### PR TITLE
fixed library extension to build properly under CYGWIN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,7 @@ ifeq ($(CAPSTONE_SHARED),yes)
 ifeq ($(IS_MINGW),1)
 LIBRARY = $(BLDIR)/$(LIBNAME).$(VERSION_EXT)
 else ifeq ($(IS_CYGWIN),1)
-LIBRARY = $(BLDIR)/$(LIBNAME).$(VERSION_EXT)
+LIBRARY = $(BLDIR)/$(LIBNAME).$(EXT)
 else	# *nix
 LIBRARY = $(BLDIR)/lib$(LIBNAME).$(VERSION_EXT)
 CFLAGS += -fvisibility=hidden
@@ -377,7 +377,7 @@ endif
 ifeq ($(CAPSTONE_SHARED),yes)
 $(LIBRARY): $(LIBOBJ)
 ifeq ($(V),0)
-	$(call log,LINK,$(@:$(BLDIR)/%=%))$(EXT)
+	$(call log,LINK,$(@:$(BLDIR)/%=%))
 	@$(create-library)
 else
 	$(create-library)
@@ -513,11 +513,11 @@ endif
 
 ifeq ($(CAPSTONE_SHARED),yes)
 define install-library
-	$(INSTALL_LIB) $(LIBRARY)$(EXT) $1
+	$(INSTALL_LIB) $(LIBRARY) $1
 	$(if $(VERSION_EXT),
 		cd $1 && \
 		rm -f lib$(LIBNAME).$(EXT) && \
-		ln -s lib$(LIBNAME).$(VERSION_EXT) lib$(LIBNAME).$(EXT))
+		ln -s lib$(LIBNAME).$(VERSION_EXT) lib$(LIBNAME))
 endef
 else
 define install-library
@@ -532,7 +532,7 @@ endef
 
 
 define create-library
-	$(CC) $(LDFLAGS) $($(LIBNAME)_LDFLAGS) $(LIBOBJ) -o $(LIBRARY)$(EXT)
+	$(CC) $(LDFLAGS) $($(LIBNAME)_LDFLAGS) $(LIBOBJ) -o $(LIBRARY)
 endef
 
 

--- a/Makefile
+++ b/Makefile
@@ -517,7 +517,7 @@ define install-library
 	$(if $(VERSION_EXT),
 		cd $1 && \
 		rm -f lib$(LIBNAME).$(EXT) && \
-		ln -s lib$(LIBNAME).$(VERSION_EXT) lib$(LIBNAME))
+		ln -s lib$(LIBNAME).$(VERSION_EXT) lib$(LIBNAME).$(EXT))
 endef
 else
 define install-library

--- a/Makefile
+++ b/Makefile
@@ -377,7 +377,7 @@ endif
 ifeq ($(CAPSTONE_SHARED),yes)
 $(LIBRARY): $(LIBOBJ)
 ifeq ($(V),0)
-	$(call log,LINK,$(@:$(BLDIR)/%=%))
+	$(call log,LINK,$(@:$(BLDIR)/%=%))$(EXT)
 	@$(create-library)
 else
 	$(create-library)
@@ -513,7 +513,7 @@ endif
 
 ifeq ($(CAPSTONE_SHARED),yes)
 define install-library
-	$(INSTALL_LIB) $(LIBRARY) $1
+	$(INSTALL_LIB) $(LIBRARY)$(EXT) $1
 	$(if $(VERSION_EXT),
 		cd $1 && \
 		rm -f lib$(LIBNAME).$(EXT) && \
@@ -532,7 +532,7 @@ endef
 
 
 define create-library
-	$(CC) $(LDFLAGS) $($(LIBNAME)_LDFLAGS) $(LIBOBJ) -o $(LIBRARY)
+	$(CC) $(LDFLAGS) $($(LIBNAME)_LDFLAGS) $(LIBOBJ) -o $(LIBRARY)$(EXT)
 endef
 
 

--- a/suite/fuzz/Makefile
+++ b/suite/fuzz/Makefile
@@ -30,11 +30,17 @@ LDFLAGS += $(foreach arch,$(LIBARCHS),-arch $(arch))
 
 LIBNAME = capstone
 
+IS_CYGWIN := $(shell $(CC) -dumpmachine 2>/dev/null | grep -i cygwin | wc -l)
+ifeq ($(IS_CYGWIN),1)
+EXT = dll
+AR_EXT = lib
+ARCHIVE = $(LIBDIR)/$(LIBNAME).$(AR_EXT)
+else
 BIN_EXT =
 AR_EXT = a
-
-
 ARCHIVE = $(LIBDIR)/lib$(LIBNAME).$(AR_EXT)
+endif
+
 
 .PHONY: all clean
 


### PR DESCRIPTION
Currently capstone fails to build under CYGWIN although it seems supported.

Please find attached the pull request to fix that (instead of "capstone." it now uses "capstone.lib" / "capstone.dll").
