### PR TITLE
M680X - remove unused s_cpu_type (#1695)

### DIFF
--- a/arch/M680X/M680XDisassembler.c
+++ b/arch/M680X/M680XDisassembler.c
@@ -2121,11 +2121,6 @@ static const cpu_tables g_cpu_tables[] = {
 	},
 };
 
-static const char *s_cpu_type[] = {
-	"INVALID", "6301", "6309", "6800", "6801", "6805", "6808",
-	"6809", "6811", "CPU12", "HCS08",
-};
-
 static bool m680x_setup_internals(m680x_info *info, e_cpu_type cpu_type,
 	uint16_t address,
 	const uint8_t *code, uint16_t code_len)
@@ -2251,12 +2246,6 @@ cs_err M680X_disassembler_init(cs_struct *ud)
 
 	if (M680X_INS_ENDING != ARR_SIZE(g_insn_props)) {
 		CS_ASSERT(M680X_INS_ENDING == ARR_SIZE(g_insn_props));
-
-		return CS_ERR_MODE;
-	}
-
-	if (M680X_CPU_TYPE_ENDING != ARR_SIZE(s_cpu_type)) {
-		CS_ASSERT(M680X_CPU_TYPE_ENDING == ARR_SIZE(s_cpu_type));
 
 		return CS_ERR_MODE;
 	}


### PR DESCRIPTION
This pr cherry-picks c93fa3a79614a0de48dcb0b9dd98156bd6326bee (#1695) from `next` into `v4` to fix the following warning:

![s_cpu_type](https://user-images.githubusercontent.com/12002672/144226869-d7aa3b16-6f03-4361-ac58-018df8906486.PNG)
(https://github.com/rizinorg/rizin/runs/4351274434?check_suite_focus=true#step:12:697)
