### PR TITLE
Fixes a few issues

### DIFF
--- a/arch/AArch64/AArch64GenAsmWriter.inc
+++ b/arch/AArch64/AArch64GenAsmWriter.inc
@@ -10389,6 +10389,7 @@ static void printInstruction(MCInst *MI, SStream *O)
   case 19:
     // FMOVXDHighr, INSvi64gpr, INSvi64lane
     SStream_concat0(O, ".d");
+    arm64_op_addVectorArrSpecifier(MI, ARM64_VAS_1D);
     printVectorIndex(MI, 2, O);
     SStream_concat0(O, ", ");
     break;
@@ -11114,6 +11115,7 @@ static void printInstruction(MCInst *MI, SStream *O)
   case 38:
     // CPYi64, DUPv2i64lane, FMOVDXHighr, INSvi64lane, UMOVvi64
     SStream_concat0(O, ".d");
+    arm64_op_addVectorArrSpecifier(MI, ARM64_VAS_1D);
     break;
   case 39:
     // CPYi8, DUPv16i8lane, DUPv8i8lane, INSvi8lane, SMOVvi8to32, SMOVvi8to64...
@@ -12141,6 +12143,7 @@ static void printInstruction(MCInst *MI, SStream *O)
   case 28:
     // FMLAv1i64_indexed, FMLAv2i64_indexed, FMLSv1i64_indexed, FMLSv2i64_ind...
     SStream_concat0(O, ".d");
+    arm64_op_addVectorArrSpecifier(MI, ARM64_VAS_1D);
     break;
   case 29:
     // FMUL_ZPmI_H

--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -698,6 +698,18 @@ void AArch64_printInst(MCInst *MI, SStream *O, void *Info)
 			case AArch64_UMOVvi32:
 				 arm64_op_addVectorArrSpecifier(MI, ARM64_VAS_1S);
 				 break;
+			case AArch64_INSvi8lane:
+				 if (MI->csh->detail) {
+				     MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1B;
+				     MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_1B;
+				 }
+				 break;
+			case AArch64_INSvi16lane:
+				 if (MI->csh->detail) {
+				     MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1H;
+				     MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_1H;
+				 }
+				 break;
 		}
 	} else {
 		printInstruction(MI, O);

--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -1550,11 +1550,11 @@ static void printGPRSeqPairsClassOperand(MCInst *MI, unsigned OpNum, SStream *O,
 #endif
 
 		MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].type = ARM64_OP_REG;
-		MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].reg = AArch64_map_vregister(Even);
+		MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].reg = Even;
 		MI->flat_insn->detail->arm64.op_count++;
 
 		MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].type = ARM64_OP_REG;
-		MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].reg = AArch64_map_vregister(Odd);
+		MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].reg = Odd;
 		MI->flat_insn->detail->arm64.op_count++;
 	}
 }

--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -2453,6 +2453,8 @@ void AArch64_post_printer(csh handle, cs_insn *flat_insn, char *insn_asm, MCInst
 			case AArch64_STRWpre:
 			case AArch64_STRXpost:
 			case AArch64_STRXpre:
+			case AArch64_LDRAAwriteback:
+			case AArch64_LDRABwriteback:
 				flat_insn->detail->arm64.writeback = true;
 				break;
 		}


### PR DESCRIPTION
Hello,

I have found a few regressions and issues while updating the Capstone library that I'm using in my project.
- The first one is related to the `vess` ARM64 field which was merged with the `vas` field. Some instructions were missing the correct VAS information,
- The second issue is a missing writeback information on two ARMv8.3 instructions (`LDRAA` and `LDRAB`),
- The last issue seems to be a copy and paste issue in the `printGPRSeqPairsClassOperand` method which was using the vector-related register mapping function `AArch64_map_vregister`.