### PR TITLE
Fix warning about Unused variables

### DIFF
--- a/cs.c
+++ b/cs.c
@@ -535,9 +535,6 @@ static int str_replace(char *result, char *target, const char *str1, char *str2)
 static void fill_insn(struct cs_struct *handle, cs_insn *insn, char *buffer, MCInst *mci,
 		PostPrinter_t postprinter, const uint8_t *code)
 {
-#ifndef CAPSTONE_DIET
-	char *sp, *mnem;
-#endif
 	uint16_t copy_size = MIN(sizeof(insn->bytes), insn->size);
 
 	// fill the instruction bytes.


### PR DESCRIPTION
This was causing a build failure when considering warnings as errors, this is a good practice and should be checked in the CI

![Screenshot 2022-01-06 at 19 50 26](https://user-images.githubusercontent.com/6431515/148435198-211e579d-5e6a-4cf7-92cd-55532481f9db.png)

reference link https://github.com/radareorg/radare2/runs/4730735642?check_suite_focus=true