### PR TITLE
test_customized_mnem: avoid abort() if x86 not supported

### DIFF
--- a/tests/test_customized_mnem.c
+++ b/tests/test_customized_mnem.c
@@ -52,8 +52,11 @@ static void test()
 
 	err = cs_open(CS_ARCH_X86, CS_MODE_32, &handle);
 	if (err) {
-		printf("Failed on cs_open() with error returned: %u\n", err);
-		abort();
+		if (cs_support(CS_ARCH_X86)) {
+			printf("Failed on cs_open() with error returned: %u\n", err);
+			abort();
+		} else
+			return;
 	}
 
 	// 1. Print out the instruction in default setup.


### PR DESCRIPTION
if the library is built without X86, then cs_open() should fail
but that shouldn't be treated as an error, so return instead after
checking.