### PR TITLE
fix lcall seg:off format for x86-16

### DIFF
--- a/suite/synctools/tablegen/X86/X86InstrControl.td
+++ b/suite/synctools/tablegen/X86/X86InstrControl.td
@@ -250,11 +250,11 @@ let isCall = 1 in
     let Predicates = [Not64BitMode], AsmVariantName = "att" in {
       def FARCALL16i  : Iseg16<0x9A, RawFrmImm16, (outs),
                                (ins i16imm:$off, i16imm:$seg),
-                               "lcall{w}\t$seg, $off", []>,
+                               "lcall{w}\t$seg : $off", []>,
                                OpSize16, Sched<[WriteJump]>;
       def FARCALL32i  : Iseg32<0x9A, RawFrmImm16, (outs),
                                (ins i32imm:$off, i16imm:$seg),
-                               "lcall{l}\t$seg, $off", []>,
+                               "lcall{l}\t$seg : $off", []>,
                                OpSize32, Sched<[WriteJump]>;
     }
 

--- a/suite/synctools/tablegen/X86/back/X86InstrControl.td
+++ b/suite/synctools/tablegen/X86/back/X86InstrControl.td
@@ -250,11 +250,11 @@ let isCall = 1 in
     let Predicates = [Not64BitMode], AsmVariantName = "att" in {
       def FARCALL16i  : Iseg16<0x9A, RawFrmImm16, (outs),
                                (ins i16imm:$off, i16imm:$seg),
-                               "lcall{w}\t$seg, $off", []>,
+                               "lcall{w}\t$seg : $off", []>,
                                OpSize16, Sched<[WriteJump]>;
       def FARCALL32i  : Iseg32<0x9A, RawFrmImm16, (outs),
                                (ins i32imm:$off, i16imm:$seg),
-                               "lcall{l}\t$seg, $off", []>,
+                               "lcall{l}\t$seg : $off", []>,
                                OpSize32, Sched<[WriteJump]>;
     }
 


### PR DESCRIPTION
I found that lcall seg:off is wrongly printed for x86-16.
```
$ ./cstool x16 9a0d000000
 0  9a 0d 00 00 00                                   lcall	0, 0xd
```
for example ljmp is correct:
```
$ ./cstool x16 ea0d000000
 0  ea 0d 00 00 00                                   ljmp	0:0xd
```

found also that this wrong format comes from this differences (skipping uninterested lines from grep output):
```
suite/synctools/tablegen/X86$ grep -r seg | grep lcall
X86InstrControl.td:                               "lcall{w}\t$seg, $off", []>,
X86InstrControl.td:                               "lcall{l}\t$seg, $off", []>,
back/X86InstrControl.td:                               "lcall{w}\t$seg, $off", []>,
back/X86InstrControl.td:                               "lcall{l}\t$seg, $off", []>,

suite/synctools/tablegen/X86$ grep -r seg | grep ljmp
X86InstrControl.td:                            "ljmp{w}\t$seg : $off", []>,
X86InstrControl.td:                            "ljmp{l}\t$seg : $off", []>,
back/X86InstrControl.td:                            "ljmp{w}\t$seg : $off", []>,
back/X86InstrControl.td:                            "ljmp{l}\t$seg : $off", []>,
```

the only need is to run llvm-tblgen
