### PR TITLE
Add the archs variable in the pkg-config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -609,4 +609,5 @@ define generate-pkgcfg
 	echo 'archive=$${libdir}/libcapstone.a' >> $(PKGCFGF)
 	echo 'Libs: -L$${libdir} -lcapstone' >> $(PKGCFGF)
 	echo 'Cflags: -I$${includedir}' >> $(PKGCFGF)
+	echo 'archs: ${CAPSTONE_ARCHS}' >> $(PKGCFGF)
 endef

--- a/capstone.pc.in
+++ b/capstone.pc.in
@@ -10,3 +10,4 @@ URL: http://www.capstone-engine.org
 archive=${libdir}/libcapstone.a
 Libs: -L${libdir} -lcapstone
 Cflags: -I${includedir}
+archs=@CAPSTONE_ARCHITECTURES@


### PR DESCRIPTION
Usage:
 $ pkg-config --variable=archs capstone
 arm aarch64 m68k mips powerpc sparc systemz x86
 xcore tms320c64x m680x evm riscv mos65xx wasm bpf