### PR TITLE
fixed incorrect MI->ac_idx leading to wrong AArch64 InsnOp access printing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -65,12 +65,12 @@ jobs:
           name: artifact
           path: dist
 
-      - name: Publish distribution 📦 to test PyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.testpypi_pass }}
-          repository_url: https://test.pypi.org/legacy/
+      # - name: Publish distribution 📦 to test PyPI
+      #   uses: pypa/gh-action-pypi-publish@master
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.testpypi_pass }}
+      #     repository_url: https://test.pypi.org/legacy/
 
       - name: Publish distribution 📦 to PyPI
         if: ${{ success() }}

--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -848,6 +848,7 @@ static void printOperand(MCInst *MI, unsigned OpNum, SStream *O)
 
 				access = get_op_access(MI->csh, MCInst_getOpcode(MI), OpNum);
 				MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].access = access;
+				MI->ac_idx++;
 #endif
 				MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].type = ARM64_OP_REG;
 				MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].reg = Reg;

--- a/suite/cstest/issues.cs
+++ b/suite/cstest/issues.cs
@@ -1,3 +1,7 @@
+!# issue 1839 AArch64 Incorrect detailed disassembly of ldr
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x41,0x00,0x40,0xf9 == ldr x1, [x2] ; operands[0].access: WRITE ; operands[1].access: READ
+
 // !# issue 1827 x86-16 lcall 0:0xd
 // !# CS_ARCH_X86, CS_MODE_16, CS_OPT_DETAIL
 // 0x9a,0x0d,0x00,0x00,0x00 == lcall 0:0xd


### PR DESCRIPTION
Fix https://github.com/capstone-engine/capstone/issues/1839 first bug