### PR TITLE
Update the table for UD0 and UD1 with the latest llvm table

### DIFF
--- a/suite/synctools/tablegen/X86/X86InstrSystem.td
+++ b/suite/synctools/tablegen/X86/X86InstrSystem.td
@@ -23,9 +23,21 @@ let Defs = [RAX, RCX, RDX] in
 // CPU flow control instructions
 
 let mayLoad = 1, mayStore = 0, hasSideEffects = 1, isTrap = 1 in {
-  def UD2    : I<0x0B, RawFrm, (outs), (ins), "ud2", [(trap)]>, TB;
-  def UD1    : I<0xB9, RawFrm, (outs), (ins), "ud1", []>, TB;
-  def UD0    : I<0xFF, RawFrm, (outs), (ins), "ud0", []>, TB;
+  def TRAP    : I<0x0B, RawFrm, (outs), (ins), "ud2", [(trap)]>, TB;
+
+  def UD1Wm   : I<0xB9, MRMSrcMem, (outs), (ins GR16:$src1, i16mem:$src2),
+                  "ud1{w} {$src2, $src1|$src1, $src2}", []>, TB, OpSize16;
+  def UD1Lm   : I<0xB9, MRMSrcMem, (outs), (ins GR32:$src1, i32mem:$src2),
+                  "ud1{l} {$src2, $src1|$src1, $src2}", []>, TB, OpSize32;
+  def UD1Qm   : RI<0xB9, MRMSrcMem, (outs), (ins GR64:$src1, i64mem:$src2),
+                   "ud1{q} {$src2, $src1|$src1, $src2}", []>, TB;
+
+  def UD1Wr   : I<0xB9, MRMSrcReg, (outs), (ins GR16:$src1, GR16:$src2),
+                  "ud1{w} {$src2, $src1|$src1, $src2}", []>, TB, OpSize16;
+  def UD1Lr   : I<0xB9, MRMSrcReg, (outs), (ins GR32:$src1, GR32:$src2),
+                  "ud1{l} {$src2, $src1|$src1, $src2}", []>, TB, OpSize32;
+  def UD1Qr   : RI<0xB9, MRMSrcReg, (outs), (ins GR64:$src1, GR64:$src2),
+                   "ud1{q} {$src2, $src1|$src1, $src2}", []>, TB;
 }
 
 def HLT : I<0xF4, RawFrm, (outs), (ins), "hlt", []>;


### PR DESCRIPTION
The change in this PR is to address the problem regarding UD0 and UD1: i.e., the capstone decoder was not able to process the arguments of these instructions correctly.

According to the X86 instruction-set manual, UD0 and UD1 (Undefined Instruction) take two arguments:
UD0 r32, r/m32
UD1 r32, r/m32
(https://www.felixcloutier.com/x86/ud)

It was observed that capstone does not read the bytes after the opcode correctly, and does not produce the two arguments.

At first, I tried to update all the tables in suite/synctools/tablegen/X86/ with the latest llvm tables, but I was getting various problems.
One of them was that any instructions with zmm regsiters as operands are decoded incorrectly.

After several hours of trial, I ended up giving up updating the whole tables, and instead, I tried updating the specific table in suite/synctools/tablegen/X86/X86InstrSystem.td, which is relevant to the particular problem that I was having with UD0 and UD1, with the llvm table https://github.com/capstone-engine/llvm-capstone/blob/dev/llvm/lib/Target/X86/X86InstrSystem.td#L25.

And I confirmed that this change resolves the observed problem.

Note that this MR does not include the changes in the generated files in arch/X86 because I was having some problem in running the scripts, and had to do some manual editing to make things work.
(Please see https://github.com/GrammaTech/capstone/pull/7 if you would like to see the changes in the generated files)

This PR is mainly to bring up the need of updating the tables with the latest llvm tables for X86 as well.
However, if the owner is willing to accept this PR with a partial update in the table, I will try to push the changes in the generated files as well.

As a side note, I am aware of this PR (https://github.com/capstone-engine/capstone/pull/1803) as an effort for automatic synchronization, but the PR does not seem to cover X86.

I also noticed that there may be an attempt at synchronizing X86 table: https://github.com/capstone-engine/llvm-capstone/issues/2 (@hainest)

@aeflores @adamjseitz
