### PR TITLE
Add CMake Package Config instructions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,41 @@
+name: CMake
+
+on: push
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macOS-latest
+          - ubuntu-20.04
+          - windows-2022
+        include:
+          - os: windows-2022
+            platform: windows
+          - os: ubuntu-20.04
+            platform: linux
+          - os: macOS-latest
+            platform: macos
+
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - uses: lukka/get-cmake@latest
+      name: Get CMake
+
+    - uses: ilammy/msvc-dev-cmd@v1  
+      name: Setup Windows dev environment
+      with:
+        arch: 'x64'
+      if: ${{ matrix.platform == 'windows' }}
+
+    - name: 'Configure, Build and Install'
+      run: |
+        cmake --preset=${{ matrix.platform }}-x64
+        cmake --build --preset build-${{ matrix.platform }}
+        cmake --build --preset install-${{ matrix.platform }}

--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,8 @@ build*/
 
 # CMake build directories
 build*/
+/build
+/out
 
 # Xcode
 xcode/Capstone.xcodeproj/xcuserdata

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,6 +507,10 @@ set_property(GLOBAL PROPERTY VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION
 ## targets
 if (CAPSTONE_BUILD_STATIC)
     add_library(capstone-static STATIC ${ALL_SOURCES} ${ALL_HEADERS})
+    target_include_directories(capstone-static
+        PUBLIC
+            $<INSTALL_INTERFACE:include>
+    )
     set_property(TARGET capstone-static PROPERTY OUTPUT_NAME capstone)
     set(default-target capstone-static)
 endif ()
@@ -527,6 +531,10 @@ endif ()
 
 if (CAPSTONE_BUILD_SHARED)
     add_library(capstone-shared SHARED ${ALL_SOURCES} ${ALL_HEADERS})
+    target_include_directories(capstone-shared
+        PUBLIC
+            $<INSTALL_INTERFACE:include>
+    )
     set_property(TARGET capstone-shared PROPERTY OUTPUT_NAME capstone)
     set_property(TARGET capstone-shared PROPERTY COMPILE_FLAGS -DCAPSTONE_SHARED)
 
@@ -596,6 +604,7 @@ source_group("Include\\MOS65XX" FILES ${HEADERS_MOS65XX})
 
 ### test library 64bit routine:
 include("GNUInstallDirs")
+include(CMakePackageConfigHelpers)
 
 ## installation
 if (CAPSTONE_INSTALL)
@@ -603,16 +612,25 @@ if (CAPSTONE_INSTALL)
 endif ()
 configure_file(capstone.pc.in ${CMAKE_BINARY_DIR}/capstone.pc @ONLY)
 
+configure_package_config_file(capstone-config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/capstone-config.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/capstone-config-version.cmake
+  VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}
+  COMPATIBILITY SameMajorVersion )
+
 if (CAPSTONE_BUILD_STATIC AND CAPSTONE_INSTALL)
     install(TARGETS capstone-static
-            RUNTIME DESTINATION bin
+            EXPORT capstone-targets
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif ()
 
 if (CAPSTONE_BUILD_SHARED AND CAPSTONE_INSTALL)
     install(TARGETS capstone-shared
-            RUNTIME DESTINATION bin
+            EXPORT capstone-targets
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif ()
@@ -623,7 +641,18 @@ add_executable(cstool ${CSTOOL_SRC})
 target_link_libraries(cstool ${default-target})
 
 if (CAPSTONE_INSTALL)
-    install(TARGETS cstool DESTINATION bin)
+    install(TARGETS cstool
+        EXPORT capstone-targets
+        DESTINATION ${CMAKE_INSTALL_BINDIR})
     install(FILES ${CMAKE_BINARY_DIR}/capstone.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif ()
+endif ()
+
+if (CAPSTONE_INSTALL)
+    install(EXPORT capstone-targets
+        NAMESPACE capstone::
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/capstone-config.cmake
+                  ${CMAKE_CURRENT_BINARY_DIR}/capstone-config-version.cmake
+            DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
 endif ()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,97 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "locations-base",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "installDir": "${sourceDir}/out/install/${presetName}"
+    },
+    {
+      "name": "warnings-base",
+      "hidden": true,
+      "warnings": {
+        "dev": true,
+        "deprecated": true,
+        "systemVars": true
+      },
+      "errors": {
+        "dev": true,
+        "deprecated": false
+      }
+    },
+    {
+      "name": "ninja",
+      "hidden": true,
+      "displayName": "Ninja",
+      "generator": "Ninja Multi-Config",
+      "cacheVariables": {
+        "CMAKE_DEFAULT_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "x64",
+      "hidden": true,
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      }
+    },
+    {
+      "name": "linux-x64",
+      "inherits": [ "ninja", "x64", "locations-base", "warnings-base" ],
+      "condition": {"type": "equals", "lhs": "${hostSystemName}", "rhs": "Linux"}
+    },
+    {
+      "name": "macos-x64",
+      "inherits": [ "ninja", "x64", "locations-base", "warnings-base" ],
+      "condition": {"type": "equals", "lhs": "${hostSystemName}", "rhs": "Darwin"}
+    },
+    {
+      "name": "windows-x64",
+      "inherits": [ "ninja", "x64", "locations-base", "warnings-base" ],
+      "condition": {"type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows"}
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "build-linux",
+      "configurePreset": "linux-x64",
+      "nativeToolOptions": [ "-v" ],
+      "condition": {"type": "equals", "lhs": "${hostSystemName}", "rhs": "Linux"}
+    },
+    {
+      "name": "build-macos",
+      "configurePreset": "macos-x64",
+      "nativeToolOptions": [ "-v" ],
+      "condition": {"type": "equals", "lhs": "${hostSystemName}", "rhs": "Darwin"}
+    },
+    {
+      "name": "build-windows",
+      "configurePreset": "windows-x64",
+      "nativeToolOptions": [ "-v" ],
+      "condition": {"type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows"}
+    },
+    {
+      "name": "install-linux",
+      "configurePreset": "linux-x64",
+      "inherits": "build-linux",
+      "targets": [ "install" ],
+      "condition": {"type": "equals", "lhs": "${hostSystemName}", "rhs": "Linux"}
+    },
+    {
+      "name": "install-macos",
+      "configurePreset": "macos-x64",
+      "inherits": "build-macos",
+      "targets": [ "install" ],
+      "condition": {"type": "equals", "lhs": "${hostSystemName}", "rhs": "Darwin"}
+    },
+    {
+      "name": "install-windows",
+      "configurePreset": "windows-x64",
+      "inherits": "build-windows",
+      "targets": [ "install" ],
+      "condition": {"type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows"}
+    }
+  ]
+}

--- a/capstone-config.cmake.in
+++ b/capstone-config.cmake.in
@@ -1,0 +1,6 @@
+
+@PACKAGE_INIT@
+
+include(capstone-targets.cmake)
+
+check_required_components(capstone)


### PR DESCRIPTION
## Description

This PR add CMake instructions so that capstone build a CMake Package config.
This feature helps a lot by providing a non-ambiguous way to integrate capstone in other CMake projects.
As an added benefit, capstone integration in package manager like `vcpkg` is also improved.

Moreover, I have added simple CMake presets and CMake CI to test those changes in an automated way.
