### PR TITLE
Fix pkgconfig not installed when CAPSTONE_BUILD_CSTOOL is false

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -639,6 +639,7 @@ if(CAPSTONE_INSTALL)
     install(FILES ${HEADERS_COMMON} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/capstone)
 
     configure_file(capstone.pc.in ${CMAKE_BINARY_DIR}/capstone.pc @ONLY)
+    install(FILES ${CMAKE_BINARY_DIR}/capstone.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
     include(CMakePackageConfigHelpers)
     set(CAPSTONE_CMAKE_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/capstone")
@@ -694,6 +695,5 @@ if(CAPSTONE_BUILD_CSTOOL)
 
     if(CAPSTONE_INSTALL)
         install(TARGETS cstool DESTINATION ${CMAKE_INSTALL_BINDIR})
-        install(FILES ${CMAKE_BINARY_DIR}/capstone.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
     endif()
 endif()


### PR DESCRIPTION
## Description

This PR fixes cases where `capstone.pc` was not installed in case `CAPSTONE_INSTALL` is set to true but `CAPSTONE_BUILD_CSTOOL` is set to false.