### PR TITLE
AArch64 comprehensively add vas specifiers to aliased instructions

### DIFF
--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -639,21 +639,21 @@ void AArch64_printInst(MCInst *MI, SStream *O, void *Info)
 		switch(MCInst_getOpcode(MI)) {
 			default: break;
 			case AArch64_LD1i8_POST:
-				 arm64_op_addImm(MI, 1);
-				 break;
+				arm64_op_addImm(MI, 1);
+				break;
 			case AArch64_LD1i16_POST:
-				 arm64_op_addImm(MI, 2);
-				 break;
+				arm64_op_addImm(MI, 2);
+				break;
 			case AArch64_LD1i32_POST:
-				 arm64_op_addImm(MI, 4);
-				 break;
+				arm64_op_addImm(MI, 4);
+				break;
 			case AArch64_LD1Onev1d_POST:
 			case AArch64_LD1Onev2s_POST:
 			case AArch64_LD1Onev4h_POST:
 			case AArch64_LD1Onev8b_POST:
 			case AArch64_LD1i64_POST:
-				 arm64_op_addImm(MI, 8);
-				 break;
+				arm64_op_addImm(MI, 8);
+				break;
 			case AArch64_LD1Onev16b_POST:
 			case AArch64_LD1Onev2d_POST:
 			case AArch64_LD1Onev4s_POST:
@@ -662,14 +662,14 @@ void AArch64_printInst(MCInst *MI, SStream *O, void *Info)
 			case AArch64_LD1Twov2s_POST:
 			case AArch64_LD1Twov4h_POST:
 			case AArch64_LD1Twov8b_POST:
-				 arm64_op_addImm(MI, 16);
-				 break;
+				arm64_op_addImm(MI, 16);
+				break;
 			case AArch64_LD1Threev1d_POST:
 			case AArch64_LD1Threev2s_POST:
 			case AArch64_LD1Threev4h_POST:
 			case AArch64_LD1Threev8b_POST:
-				 arm64_op_addImm(MI, 24);
-				 break;
+				arm64_op_addImm(MI, 24);
+				break;
 			case AArch64_LD1Fourv1d_POST:
 			case AArch64_LD1Fourv2s_POST:
 			case AArch64_LD1Fourv4h_POST:
@@ -678,8 +678,8 @@ void AArch64_printInst(MCInst *MI, SStream *O, void *Info)
 			case AArch64_LD1Twov2d_POST:
 			case AArch64_LD1Twov4s_POST:
 			case AArch64_LD1Twov8h_POST:
-				 arm64_op_addImm(MI, 32);
-				 break;
+				arm64_op_addImm(MI, 32);
+				break;
 			case AArch64_LD1Threev16b_POST:
 			case AArch64_LD1Threev2d_POST:
 			case AArch64_LD1Threev4s_POST:
@@ -690,40 +690,40 @@ void AArch64_printInst(MCInst *MI, SStream *O, void *Info)
 			case AArch64_LD1Fourv2d_POST:
 			case AArch64_LD1Fourv4s_POST:
 			case AArch64_LD1Fourv8h_POST:
-				 arm64_op_addImm(MI, 64);
-				 break;
+				arm64_op_addImm(MI, 64);
+				break;
 			case AArch64_UMOVvi64:
-				 arm64_op_addVectorArrSpecifier(MI, ARM64_VAS_1D);
-				 break;
+				arm64_op_addVectorArrSpecifier(MI, ARM64_VAS_1D);
+				break;
 			case AArch64_UMOVvi32:
-				 arm64_op_addVectorArrSpecifier(MI, ARM64_VAS_1S);
-				 break;
+				arm64_op_addVectorArrSpecifier(MI, ARM64_VAS_1S);
+				break;
 			case AArch64_INSvi8lane:
-				 if (MI->csh->detail) {
-				     MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1B;
-				     MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_1B;
-				 }
+				if (MI->csh->detail) {
+					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1B;
+					MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_1B;
+				}
 				 break;
 			case AArch64_INSvi16lane:
-				 if (MI->csh->detail) {
-				     MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1H;
-				     MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_1H;
-				 }
+				if (MI->csh->detail) {
+					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1H;
+					MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_1H;
+				}
 				 break;
 			case AArch64_ORRv16i8:
 			case AArch64_NOTv16i8:
-				 if (MI->csh->detail) {
-				     MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_16B;
-				     MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_16B;
-				 }
-				 break;
+				if (MI->csh->detail) {
+					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_16B;
+					MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_16B;
+				}
+				break;
 			case AArch64_ORRv8i8:
 			case AArch64_NOTv8i8:
-				 if (MI->csh->detail) {
-				     MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_8B;
-				     MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_8B;
-				 }
-				 break;
+				if (MI->csh->detail) {
+					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_8B;
+					MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_8B;
+				}
+				break;
 		}
 	} else {
 		printInstruction(MI, O);

--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -698,18 +698,83 @@ void AArch64_printInst(MCInst *MI, SStream *O, void *Info)
 			case AArch64_UMOVvi32:
 				arm64_op_addVectorArrSpecifier(MI, ARM64_VAS_1S);
 				break;
+			case AArch64_INSvi8gpr:
+			case AArch64_DUP_ZI_B:
+			case AArch64_CPY_ZPmI_B:
+			case AArch64_CPY_ZPzI_B:
+			case AArch64_CPY_ZPmV_B:
+			case AArch64_CPY_ZPmR_B:
+			case AArch64_DUP_ZR_B:
+				if (MI->csh->detail) {
+					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1B;
+				}
+				break;
+			case AArch64_INSvi16gpr:
+			case AArch64_DUP_ZI_H:
+			case AArch64_CPY_ZPmI_H:
+			case AArch64_CPY_ZPzI_H:
+			case AArch64_CPY_ZPmV_H:
+			case AArch64_CPY_ZPmR_H:
+			case AArch64_DUP_ZR_H:
+			case AArch64_FCPY_ZPmI_H:
+			case AArch64_FDUP_ZI_H:
+				if (MI->csh->detail) {
+					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1H;
+				}
+				break;
+			case AArch64_INSvi32gpr:
+			case AArch64_DUP_ZI_S:
+			case AArch64_CPY_ZPmI_S:
+			case AArch64_CPY_ZPzI_S:
+			case AArch64_CPY_ZPmV_S:
+			case AArch64_CPY_ZPmR_S:
+			case AArch64_DUP_ZR_S:
+			case AArch64_FCPY_ZPmI_S:
+			case AArch64_FDUP_ZI_S:
+				if (MI->csh->detail) {
+					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1S;
+				}
+				break;
+			case AArch64_INSvi64gpr:
+			case AArch64_DUP_ZI_D:
+			case AArch64_CPY_ZPmI_D:
+			case AArch64_CPY_ZPzI_D:
+			case AArch64_CPY_ZPmV_D:
+			case AArch64_CPY_ZPmR_D:
+			case AArch64_DUP_ZR_D:
+			case AArch64_FCPY_ZPmI_D:
+			case AArch64_FDUP_ZI_D:
+				if (MI->csh->detail) {
+					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1D;
+				}
+				break;
 			case AArch64_INSvi8lane:
+			case AArch64_ORR_PPzPP:
+			case AArch64_ORRS_PPzPP:
 				if (MI->csh->detail) {
 					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1B;
 					MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_1B;
 				}
-				 break;
+				break;
 			case AArch64_INSvi16lane:
 				if (MI->csh->detail) {
 					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1H;
 					MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_1H;
 				}
 				 break;
+			case AArch64_INSvi32lane:
+				if (MI->csh->detail) {
+					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1S;
+					MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_1S;
+				}
+				break;
+			case AArch64_INSvi64lane:
+			case AArch64_ORR_ZZZ:
+				if (MI->csh->detail) {
+					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1D;
+					MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_1D;
+				}
+				break;
 			case AArch64_ORRv16i8:
 			case AArch64_NOTv16i8:
 				if (MI->csh->detail) {
@@ -722,6 +787,85 @@ void AArch64_printInst(MCInst *MI, SStream *O, void *Info)
 				if (MI->csh->detail) {
 					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_8B;
 					MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_8B;
+				}
+				break;
+			case AArch64_AND_PPzPP:
+			case AArch64_ANDS_PPzPP:
+			case AArch64_EOR_PPzPP:
+			case AArch64_EORS_PPzPP:
+			case AArch64_SEL_PPPP:
+			case AArch64_SEL_ZPZZ_B:
+				if (MI->csh->detail) {
+					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1B;
+					MI->flat_insn->detail->arm64.operands[2].vas = ARM64_VAS_1B;
+				}
+				break;
+			case AArch64_SEL_ZPZZ_D:
+				if (MI->csh->detail) {
+					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1D;
+					MI->flat_insn->detail->arm64.operands[2].vas = ARM64_VAS_1D;
+				}
+				break;
+			case AArch64_SEL_ZPZZ_H:
+				if (MI->csh->detail) {
+					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1H;
+					MI->flat_insn->detail->arm64.operands[2].vas = ARM64_VAS_1H;
+				}
+				break;
+			case AArch64_SEL_ZPZZ_S:
+				if (MI->csh->detail) {
+					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1S;
+					MI->flat_insn->detail->arm64.operands[2].vas = ARM64_VAS_1S;
+				}
+				break;
+			case AArch64_DUP_ZZI_B:
+				if (MI->csh->detail) {
+					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1B;
+					if (MI->flat_insn->detail->arm64.op_count == 1) {
+						arm64_op_addReg(MI, ARM64_REG_B0 + MCOperand_getReg(MCInst_getOperand(MI, 1)) - ARM64_REG_Z0);
+					} else {
+						MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_1B;
+					}
+				}
+				break;
+			case AArch64_DUP_ZZI_D:
+				if (MI->csh->detail) {
+					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1D;
+					if (MI->flat_insn->detail->arm64.op_count == 1) {
+						arm64_op_addReg(MI, ARM64_REG_D0 + MCOperand_getReg(MCInst_getOperand(MI, 1)) - ARM64_REG_Z0);
+					} else {
+						MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_1D;
+					}
+				}
+				break;
+			case AArch64_DUP_ZZI_H:
+				if (MI->csh->detail) {
+					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1H;
+					if (MI->flat_insn->detail->arm64.op_count == 1) {
+						arm64_op_addReg(MI, ARM64_REG_H0 + MCOperand_getReg(MCInst_getOperand(MI, 1)) - ARM64_REG_Z0);
+					} else {
+						MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_1H;
+					}
+				}
+				break;
+			case AArch64_DUP_ZZI_Q:
+				if (MI->csh->detail) {
+					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1Q;
+					if (MI->flat_insn->detail->arm64.op_count == 1) {
+						arm64_op_addReg(MI, ARM64_REG_Q0 + MCOperand_getReg(MCInst_getOperand(MI, 1)) - ARM64_REG_Z0);
+					} else {
+						MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_1Q;
+					}
+				 }
+				 break;
+			case AArch64_DUP_ZZI_S:
+				if (MI->csh->detail) {
+					MI->flat_insn->detail->arm64.operands[0].vas = ARM64_VAS_1S;
+					if (MI->flat_insn->detail->arm64.op_count == 1) {
+				 		arm64_op_addReg(MI, ARM64_REG_S0 + MCOperand_getReg(MCInst_getOperand(MI, 1)) - ARM64_REG_Z0);
+					} else {
+						 MI->flat_insn->detail->arm64.operands[1].vas = ARM64_VAS_1S;
+					}
 				}
 				break;
 		}

--- a/arch/AArch64/AArch64Mapping.c
+++ b/arch/AArch64/AArch64Mapping.c
@@ -607,6 +607,15 @@ arm64_sys_op AArch64_map_sys_op(const char *name)
 	return result;
 }
 
+void arm64_op_addReg(MCInst *MI, int reg)
+{
+	if (MI->csh->detail) {
+		MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].type = ARM64_OP_REG;
+		MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].reg = reg;
+		MI->flat_insn->detail->arm64.op_count++;
+	}
+}
+
 void arm64_op_addVectorArrSpecifier(MCInst * MI, int sp)
 {
 	if (MI->csh->detail) {

--- a/suite/cstest/issues.cs
+++ b/suite/cstest/issues.cs
@@ -1,3 +1,135 @@
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x21,0x04,0x03,0x5e == mov b1, v1.b[1] ; operands[1].vas: 0x4 ; operands[1].vector_index: 1
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0xc0,0x1e,0x03,0x4e == mov v0.b[1], w22 ; operands[0].vas: 0x4 ; operands[0].vector_index: 1
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0xc0,0x1e,0x06,0x4e == mov v0.h[1], w22 ; operands[0].vas: 0x8 ; operands[0].vector_index: 1
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0xc0,0x1e,0x0c,0x4e == mov v0.s[1], w22 ; operands[0].vas: 0xb ; operands[0].vector_index: 1
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0xc0,0x1e,0x18,0x4e == mov v0.d[1], x22 ; operands[0].vas: 0xd ; operands[0].vector_index: 1
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x20,0x0c,0x03,0x6e == mov v0.b[1], v1.b[1] ; operands[0].vas: 0x4 ; operands[0].vector_index: 1 ; operands[1].vas: 0x4 ; operands[1].vector_index: 1
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x20,0x14,0x06,0x6e == mov v0.h[1], v1.h[1] ; operands[0].vas: 0x8 ; operands[0].vector_index: 1 ; operands[1].vas: 0x8 ; operands[1].vector_index: 1
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x20,0x24,0x0c,0x6e == mov v0.s[1], v1.s[1] ; operands[0].vas: 0xb ; operands[0].vector_index: 1 ; operands[1].vas: 0xb ; operands[1].vector_index: 1
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x20,0x44,0x18,0x6e == mov v0.d[1], v1.d[1] ; operands[0].vas: 0xd ; operands[0].vector_index: 1 ; operands[1].vas: 0xd ; operands[1].vector_index: 1
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x20,0x3c,0x0c,0x0e == mov w0, v1.s[1] ; operands[1].vas: 0xb ; operands[1].vector_index: 1
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x20,0x3c,0x0c,0x0e == mov w0, v1.s[1] ; operands[1].vas: 0xb ; operands[1].vector_index: 1
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x20,0x3c,0x18,0x4e == mov x0, v1.d[1] ; operands[1].vas: 0xd ; operands[1].vector_index: 1
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x20,0x3c,0x18,0x4e == mov x0, v1.d[1] ; operands[1].vas: 0xd ; operands[1].vector_index: 1
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x00,0xc0,0x50,0x05 == fmov z0.h, p0/m, #2.00000000 ; operands[0].vas: 0x8
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x00,0xc0,0x79,0x25 == fmov z0.h, #2.00000000 ; operands[0].vas: 0x8
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0xa1,0xca,0xf8,0x25 == mov z1.d, #0x55 ; operands[0].vas: 0xd
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x21,0x44,0x81,0x25 == mov p1.b, p1.b ; operands[0].vas: 0x4 ; operands[1].vas: 0x4
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x21,0x40,0x51,0x05 == mov z1.h, p1/m, #1 ; operands[0].vas: 0x8
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x21,0x00,0x51,0x05 == mov z1.h, p1/z, #1 ; operands[0].vas: 0x8
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x20,0xc0,0x38,0x25 == mov z0.b, #1 ; operands[0].vas: 0x4
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x71,0x4a,0x01,0x25 == mov p1.b, p2/m, p3.b ; operands[0].vas: 0x4 ; operands[2].vas: 0x4
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x61,0x48,0x03,0x25 == mov p1.b, p2/z, p3.b ; operands[0].vas: 0x4 ; operands[2].vas: 0x4
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x21,0xa8,0x28,0x05 == mov z1.b, p2/m, w1 ; operands[0].vas: 0x4
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x21,0x38,0x20,0x05 == mov z1.b, w1 ; operands[0].vas: 0x4
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x01,0x88,0x20,0x05 == mov z1.b, p2/m, b0 ; operands[0].vas: 0x4
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x00,0x20,0x21,0x05 == mov z0.b, b0 ; operands[0].vas: 0x4
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x00,0x20,0x23,0x05 == mov z0.b, z0.b[1] ; operands[0].vas: 0x4 ; operands[1].vas: 0x4 ; operands[1].vector_index: 1
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x20,0xc4,0x20,0x05 == mov z0.b, p1/m, z1.b ; operands[0].vas: 0x4 ; operands[2].vas: 0x4
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x20,0x30,0x61,0x04 == mov z0.d, z1.d ; operands[0].vas: 0xd ; operands[1].vas: 0xd
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x40,0x44,0x42,0x25 == movs p0.b, p1/z, p2.b ; operands[0].vas: 0x4 ; operands[2].vas: 0x4
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x20,0x44,0xc1,0x25 == movs p0.b, p1.b ; operands[0].vas: 0x4 ; operands[1].vas: 0x4
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x40,0x46,0x01,0x25 == not p0.b, p1/z, p2.b ; operands[0].vas: 0x4 ; operands[2].vas: 0x4
+
+!# issue 1873 AArch64 missing VAS specifiers in aliased instructions
+!# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+0x40,0x46,0x41,0x25 == nots p0.b, p1/z, p2.b ; operands[0].vas: 0x4 ; operands[2].vas: 0x4
+
 !# issue 1856 AArch64 SYS instruction operands: tlbi 1 op
 !# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
 0x1f,0x83,0x08,0xd5 == tlbi vmalle1is ; op_count: 1 ; operands[0].type: SYS = 0x3

--- a/suite/cstest/src/arm64_detail.c
+++ b/suite/cstest/src/arm64_detail.c
@@ -103,7 +103,7 @@ char *get_detail_arm64(csh *handle, cs_mode mode, cs_insn *ins)
 			add_str(&result, " ; operands[%u].vas: 0x%x", i, op->vas);
 
 		if (op->vector_index != -1)
-			add_str(&result, " ; Vector Index: %u", op->vector_index);
+			add_str(&result, " ; operands[%u].vector_index: %u", i, op->vector_index);
 	}
 
 	if (arm64->update_flags)


### PR DESCRIPTION
I attempted to comprehensively go through the ARM Architecture Reference Manual to find all the aliased instructions that should have `.vas` specifiers and fix them all.

Fixes #1873