### PR TITLE
Fix pkg-config template

### DIFF
--- a/capstone.pc.in
+++ b/capstone.pc.in
@@ -5,7 +5,7 @@ includedir=${prefix}/include
 
 Name: capstone
 Description: Capstone disassembly engine
-Version: @VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@
+Version: @PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@
 URL: http://www.capstone-engine.org
 archive=${libdir}/libcapstone.a
 Libs: -L${libdir} -lcapstone


### PR DESCRIPTION
c8172e4c107201dd8c2b4644fc73661752ac82fc dropped the CMake variables `VERSION_MAJOR`, `VERSION_MINOR` and `VERSION_PATCH` which were still in use in `capstone.pc.in`. This PR fixes the pkg-config template to reflect the current version.