### PR TITLE
Mark cs_* as thread local to avoid race condition in multithreads

### DIFF
--- a/cs.c
+++ b/cs.c
@@ -285,27 +285,26 @@ static const uint32_t all_arch = 0
 #endif
 ;
 
-
 #if defined(CAPSTONE_USE_SYS_DYN_MEM)
 #if !defined(CAPSTONE_HAS_OSXKERNEL) && !defined(_KERNEL_MODE)
 // default
-cs_malloc_t cs_mem_malloc = malloc;
-cs_calloc_t cs_mem_calloc = calloc;
-cs_realloc_t cs_mem_realloc = realloc;
-cs_free_t cs_mem_free = free;
+thread_local cs_malloc_t cs_mem_malloc = malloc;
+thread_local cs_calloc_t cs_mem_calloc = calloc;
+thread_local cs_realloc_t cs_mem_realloc = realloc;
+thread_local cs_free_t cs_mem_free = free;
 #if defined(_WIN32_WCE)
-cs_vsnprintf_t cs_vsnprintf = _vsnprintf;
+thread_local cs_vsnprintf_t cs_vsnprintf = _vsnprintf;
 #else
-cs_vsnprintf_t cs_vsnprintf = vsnprintf;
+thread_local cs_vsnprintf_t cs_vsnprintf = vsnprintf;
 #endif  // defined(_WIN32_WCE)
 
 #elif defined(_KERNEL_MODE)
 // Windows driver
-cs_malloc_t cs_mem_malloc = cs_winkernel_malloc;
-cs_calloc_t cs_mem_calloc = cs_winkernel_calloc;
-cs_realloc_t cs_mem_realloc = cs_winkernel_realloc;
-cs_free_t cs_mem_free = cs_winkernel_free;
-cs_vsnprintf_t cs_vsnprintf = cs_winkernel_vsnprintf;
+thread_local cs_malloc_t cs_mem_malloc = cs_winkernel_malloc;
+thread_local cs_calloc_t cs_mem_calloc = cs_winkernel_calloc;
+thread_local cs_realloc_t cs_mem_realloc = cs_winkernel_realloc;
+thread_local cs_free_t cs_mem_free = cs_winkernel_free;
+thread_local cs_vsnprintf_t cs_vsnprintf = cs_winkernel_vsnprintf;
 #else
 // OSX kernel
 extern void* kern_os_malloc(size_t size);
@@ -317,19 +316,19 @@ static void* cs_kern_os_calloc(size_t num, size_t size)
 	return kern_os_malloc(num * size); // malloc bzeroes the buffer
 }
 
-cs_malloc_t cs_mem_malloc = kern_os_malloc;
-cs_calloc_t cs_mem_calloc = cs_kern_os_calloc;
-cs_realloc_t cs_mem_realloc = kern_os_realloc;
-cs_free_t cs_mem_free = kern_os_free;
-cs_vsnprintf_t cs_vsnprintf = vsnprintf;
+thread_local cs_malloc_t cs_mem_malloc = kern_os_malloc;
+thread_local cs_calloc_t cs_mem_calloc = cs_kern_os_calloc;
+thread_local cs_realloc_t cs_mem_realloc = kern_os_realloc;
+thread_local cs_free_t cs_mem_free = kern_os_free;
+thread_local cs_vsnprintf_t cs_vsnprintf = vsnprintf;
 #endif  // !defined(CAPSTONE_HAS_OSXKERNEL) && !defined(_KERNEL_MODE)
 #else
 // User-defined
-cs_malloc_t cs_mem_malloc = NULL;
-cs_calloc_t cs_mem_calloc = NULL;
-cs_realloc_t cs_mem_realloc = NULL;
-cs_free_t cs_mem_free = NULL;
-cs_vsnprintf_t cs_vsnprintf = NULL;
+thread_local cs_malloc_t cs_mem_malloc = NULL;
+thread_local cs_calloc_t cs_mem_calloc = NULL;
+thread_local cs_realloc_t cs_mem_realloc = NULL;
+thread_local cs_free_t cs_mem_free = NULL;
+thread_local cs_vsnprintf_t cs_vsnprintf = NULL;
 
 #endif  // defined(CAPSTONE_USE_SYS_DYN_MEM)
 

--- a/cs_priv.h
+++ b/cs_priv.h
@@ -83,11 +83,22 @@ struct cs_struct {
 // Returns a bool (0 or 1) whether big endian is enabled for a mode
 #define MODE_IS_BIG_ENDIAN(mode) (((mode) & CS_MODE_BIG_ENDIAN) != 0)
 
-extern cs_malloc_t cs_mem_malloc;
-extern cs_calloc_t cs_mem_calloc;
-extern cs_realloc_t cs_mem_realloc;
-extern cs_free_t cs_mem_free;
-extern cs_vsnprintf_t cs_vsnprintf;
+
+#ifndef thread_local
+#if defined (__GNUC__) || defined (__clang__)
+#define thread_local __thread // prior to C11
+#elif _MSC_VER
+#define thread_local __declspec( thread ) // early msvc
+#else
+#define thread_local // failsafe
+#endif
+#endif
+
+extern thread_local cs_malloc_t cs_mem_malloc;
+extern thread_local cs_calloc_t cs_mem_calloc;
+extern thread_local cs_realloc_t cs_mem_realloc;
+extern thread_local cs_free_t cs_mem_free;
+extern thread_local cs_vsnprintf_t cs_vsnprintf;
 
 // By defining CAPSTONE_DEBUG assertions can be used.
 // For any release build CAPSTONE_DEBUG has to be undefined.


### PR DESCRIPTION
Per @trufae reported,

```
=================================================================
==251167==ERROR: AddressSanitizer: odr-violation (0x7f5cd9115f40):
  [1] size=8 'cs_vsnprintf' cs.c:299:16
  [2] size=8 'cs_vsnprintf' cs.c:299:16
These globals were registered at these points:
  [1]:
    #0 0x7f5ce2a20938 in __asan_register_globals ../../../../src/libsanitizer/asan/asan_globals.cpp:341
    #1 0x7f5cd5fbc712 in _sub_I_00099_1 (/usr/local/lib/libr_anal.so+0x3260712)
    #2 0x7f5ce3401b99 in call_init /build/glibc-SzIz7B/glibc-2.31/elf/dl-init.c:72

  [2]:
    #0 0x7f5ce2a20938 in __asan_register_globals ../../../../src/libsanitizer/asan/asan_globals.cpp:341
    #1 0x7f5cde789b44 in _sub_I_00099_1 (/usr/local/lib/libr_asm.so+0x103db44)
    #2 0x7f5ce3401b99 in call_init /build/glibc-SzIz7B/glibc-2.31/elf/dl-init.c:72

==251167==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
SUMMARY: AddressSanitizer: odr-violation: global 'cs_vsnprintf' at cs.c:299:16
==251167==ABORTING
```

This PR marks `cs_*` variables as `thread_local` to avoid race access in multiple threads. For platforms that don't support `thread_local`, this PR does nothing.