### PR TITLE
Remove outdated ctypes requirement

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -223,7 +223,6 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
     ],
-    requires=['ctypes'],
     cmdclass=cmdclass,
     zip_safe=True,
     include_package_data=True,


### PR DESCRIPTION
The library ctypes has shipped with the python standard library since
Python 2.5, however this was still added via the `requires` keyword in
setuptools.setup. This results in a spurious requirement being created
in the .whl METADATA file, causing warnings when packaged via tools like
pex:

```
$ python3 -m pex capstone -o capstone.pex
/Users/ott/.venv/lib/python3.9/site-packages/pex/dist_metadata.py:397: PEXWarning: Ignoring 1 `Requires` field in /Users/ott/.pex/installed_wheels/2a4c7a0d4c87aceed3134ae20997a764af1811fee8e151cf5da90e0462822893/capstone-4.0.2-py3-none-macosx_12_arm64.whl metadata:
1.) Requires: ctypes

You may have issues using the 'capstone' distribution as a result.
More information on this workaround can be found here:
  https://github.com/pantsbuild/pex/issues/1201#issuecomment-791715585
```

Since this requirement is outdated, it can just be removed.