### PR TITLE
Fix memory leak in testsuite

### DIFF
--- a/suite/arm/test_arm_regression.c
+++ b/suite/arm/test_arm_regression.c
@@ -336,6 +336,8 @@ static void test_valids()
 					valid->platform_comment, hex_str, valid_code->start_addr, 
 					valid_code->comment, valid_code->expected_out);
 
+			free(hex_str);
+
 			count = cs_disasm(handle,
 					valid_code->code, valid_code->size, 
 					valid_code->start_addr, 0, &insn


### PR DESCRIPTION
Prevents spurious error when compiling the test suite with `-fsanitize=address`.