### PR TITLE
m68k: Add support for the FNOP instruction

### DIFF
--- a/arch/M68K/M68KDisassembler.c
+++ b/arch/M68K/M68KDisassembler.c
@@ -1803,8 +1803,6 @@ static void d68020_cpbcc_32(m68k_info *info)
 
 	LIMIT_CPU_TYPES(info, M68020_PLUS);
 
-	LIMIT_CPU_TYPES(info, M68020_PLUS);
-
 	// these are all in row with the extension so just doing a add here is fine
 	info->inst->Opcode += (info->ir & 0x2f);
 

--- a/arch/M68K/M68KDisassembler.c
+++ b/arch/M68K/M68KDisassembler.c
@@ -1784,6 +1784,13 @@ static void d68020_cpbcc_16(m68k_info *info)
 	cs_m68k* ext;
 	LIMIT_CPU_TYPES(info, M68020_PLUS);
 
+	// FNOP is a special case of FBF
+	if (info->ir == 0xf280 && peek_imm_16(info) == 0) {
+		MCInst_setOpcode(info->inst, M68K_INS_FNOP);
+		info->pc += 2;
+		return;
+	}
+
 	// these are all in row with the extension so just doing a add here is fine
 	info->inst->Opcode += (info->ir & 0x2f);
 


### PR DESCRIPTION
FNOP is a special case of FBF which can be used for synchronization