### PR TITLE
Fixed SME index alias printing issue.

### DIFF
--- a/arch/AArch64/AArch64GenAsmWriter.inc
+++ b/arch/AArch64/AArch64GenAsmWriter.inc
@@ -26277,6 +26277,7 @@ static char *printAliasInstr(MCInst *MI, SStream *OS, MCRegisterInfo *MRI)
       ++I;
     }
 
+    bool isSME = false;
     do {
       if (AsmString[I] == '$') {
         ++I;
@@ -26289,9 +26290,19 @@ static char *printAliasInstr(MCInst *MI, SStream *OS, MCRegisterInfo *MRI)
           printOperand(MI, (unsigned)(AsmString[I++]) - 1, OS);
       } else {
         if (AsmString[I] == '[') {
-          set_mem_access(MI, true);
+          if (AsmString[I-1] != ' '){
+            set_sme_index(MI, true);
+            isSME = true;
+          } else {
+            set_mem_access(MI, true);
+          }
         } else if (AsmString[I] == ']') {
-          set_mem_access(MI, false);
+          if (isSME) {
+            set_sme_index(MI, false);
+            isSME = false;
+          } else {
+            set_mem_access(MI, false);
+          }
         }
         SStream_concat1(OS, AsmString[I++]);
       }

--- a/suite/synctools/asmwriter.py
+++ b/suite/synctools/asmwriter.py
@@ -768,6 +768,7 @@ for line in lines:
       ++I;
     }
 
+    bool isSME = false;
     do {
       if (AsmString[I] == '$') {
         ++I;
@@ -780,9 +781,19 @@ for line in lines:
           printOperand(MI, (unsigned)(AsmString[I++]) - 1, OS);
       } else {
         if (AsmString[I] == '[') {
-          set_mem_access(MI, true);
+          if (AsmString[I-1] != ' ') {
+            set_sme_index(MI, true);
+            isSME = true;
+          } else {
+            set_mem_access(MI, true);
+          }
         } else if (AsmString[I] == ']') {
-          set_mem_access(MI, false);
+          if (isSME) {
+            set_sme_index(MI, false);
+            isSME = false;
+          } else {
+            set_mem_access(MI, false);
+          }
         }
         SStream_concat1(OS, AsmString[I++]);
       }


### PR DESCRIPTION
This fixes issue #1924 where some SME instructions were not being printed correctly when aliased as the SME index was being recognised as a memory operand by mistake.