### PR TITLE
Revert "Mark cs_* as thread local to avoid race condition in multithreads"

### DIFF
--- a/cs.c
+++ b/cs.c
@@ -285,26 +285,27 @@ static const uint32_t all_arch = 0
 #endif
 ;
 
+
 #if defined(CAPSTONE_USE_SYS_DYN_MEM)
 #if !defined(CAPSTONE_HAS_OSXKERNEL) && !defined(_KERNEL_MODE)
 // default
-thread_local cs_malloc_t cs_mem_malloc = malloc;
-thread_local cs_calloc_t cs_mem_calloc = calloc;
-thread_local cs_realloc_t cs_mem_realloc = realloc;
-thread_local cs_free_t cs_mem_free = free;
+cs_malloc_t cs_mem_malloc = malloc;
+cs_calloc_t cs_mem_calloc = calloc;
+cs_realloc_t cs_mem_realloc = realloc;
+cs_free_t cs_mem_free = free;
 #if defined(_WIN32_WCE)
-thread_local cs_vsnprintf_t cs_vsnprintf = _vsnprintf;
+cs_vsnprintf_t cs_vsnprintf = _vsnprintf;
 #else
-thread_local cs_vsnprintf_t cs_vsnprintf = vsnprintf;
+cs_vsnprintf_t cs_vsnprintf = vsnprintf;
 #endif  // defined(_WIN32_WCE)
 
 #elif defined(_KERNEL_MODE)
 // Windows driver
-thread_local cs_malloc_t cs_mem_malloc = cs_winkernel_malloc;
-thread_local cs_calloc_t cs_mem_calloc = cs_winkernel_calloc;
-thread_local cs_realloc_t cs_mem_realloc = cs_winkernel_realloc;
-thread_local cs_free_t cs_mem_free = cs_winkernel_free;
-thread_local cs_vsnprintf_t cs_vsnprintf = cs_winkernel_vsnprintf;
+cs_malloc_t cs_mem_malloc = cs_winkernel_malloc;
+cs_calloc_t cs_mem_calloc = cs_winkernel_calloc;
+cs_realloc_t cs_mem_realloc = cs_winkernel_realloc;
+cs_free_t cs_mem_free = cs_winkernel_free;
+cs_vsnprintf_t cs_vsnprintf = cs_winkernel_vsnprintf;
 #else
 // OSX kernel
 extern void* kern_os_malloc(size_t size);
@@ -316,19 +317,19 @@ static void* cs_kern_os_calloc(size_t num, size_t size)
 	return kern_os_malloc(num * size); // malloc bzeroes the buffer
 }
 
-thread_local cs_malloc_t cs_mem_malloc = kern_os_malloc;
-thread_local cs_calloc_t cs_mem_calloc = cs_kern_os_calloc;
-thread_local cs_realloc_t cs_mem_realloc = kern_os_realloc;
-thread_local cs_free_t cs_mem_free = kern_os_free;
-thread_local cs_vsnprintf_t cs_vsnprintf = vsnprintf;
+cs_malloc_t cs_mem_malloc = kern_os_malloc;
+cs_calloc_t cs_mem_calloc = cs_kern_os_calloc;
+cs_realloc_t cs_mem_realloc = kern_os_realloc;
+cs_free_t cs_mem_free = kern_os_free;
+cs_vsnprintf_t cs_vsnprintf = vsnprintf;
 #endif  // !defined(CAPSTONE_HAS_OSXKERNEL) && !defined(_KERNEL_MODE)
 #else
 // User-defined
-thread_local cs_malloc_t cs_mem_malloc = NULL;
-thread_local cs_calloc_t cs_mem_calloc = NULL;
-thread_local cs_realloc_t cs_mem_realloc = NULL;
-thread_local cs_free_t cs_mem_free = NULL;
-thread_local cs_vsnprintf_t cs_vsnprintf = NULL;
+cs_malloc_t cs_mem_malloc = NULL;
+cs_calloc_t cs_mem_calloc = NULL;
+cs_realloc_t cs_mem_realloc = NULL;
+cs_free_t cs_mem_free = NULL;
+cs_vsnprintf_t cs_vsnprintf = NULL;
 
 #endif  // defined(CAPSTONE_USE_SYS_DYN_MEM)
 

--- a/cs_priv.h
+++ b/cs_priv.h
@@ -84,22 +84,11 @@ struct cs_struct {
 // Returns a bool (0 or 1) whether big endian is enabled for a mode
 #define MODE_IS_BIG_ENDIAN(mode) (((mode) & CS_MODE_BIG_ENDIAN) != 0)
 
-
-#ifndef thread_local
-#if defined (__GNUC__) || defined (__clang__)
-#define thread_local __thread // prior to C11
-#elif _MSC_VER
-#define thread_local __declspec( thread ) // early msvc
-#else
-#define thread_local // failsafe
-#endif
-#endif
-
-extern thread_local cs_malloc_t cs_mem_malloc;
-extern thread_local cs_calloc_t cs_mem_calloc;
-extern thread_local cs_realloc_t cs_mem_realloc;
-extern thread_local cs_free_t cs_mem_free;
-extern thread_local cs_vsnprintf_t cs_vsnprintf;
+extern cs_malloc_t cs_mem_malloc;
+extern cs_calloc_t cs_mem_calloc;
+extern cs_realloc_t cs_mem_realloc;
+extern cs_free_t cs_mem_free;
+extern cs_vsnprintf_t cs_vsnprintf;
 
 // By defining CAPSTONE_DEBUG assertions can be used.
 // For any release build CAPSTONE_DEBUG has to be undefined.


### PR DESCRIPTION
Having per-thread memory allocation routines is a major change in behavior that likely broke a lot of applications.

This reverts commit bdab89496e654d043f556e27a68c2ac47dd571a7.