### PR TITLE
Fix regressions in custom memory allocator support

### DIFF
--- a/arch/AArch64/AArch64Disassembler.c
+++ b/arch/AArch64/AArch64Disassembler.c
@@ -264,8 +264,8 @@ static DecodeStatus _getInstruction(cs_struct *ud, MCInst *MI,
 
 	// Init new MCOperand to be used in switch below.
 	// Kind RegVal set inside a case when needed.
-	MCOperand *Op;
-	Op = malloc(sizeof(MCOperand));
+	MCOperand op_storage;
+	MCOperand *Op = &op_storage;
 	switch (MCInst_getOpcode(MI)) {
     	default:
     	  break;
@@ -342,7 +342,6 @@ static DecodeStatus _getInstruction(cs_struct *ud, MCInst *MI,
 		  MCInst_addOperand2(MI, Op);
     	  break;
     }
-	free(Op);
 
 	if (result != MCDisassembler_Fail) {
 		*Size = 4;

--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -2485,7 +2485,7 @@ static void printMatrixTileVector(MCInst *MI, unsigned OpNum, SStream *O, bool I
 
 	const size_t strLn = strlen(RegName);
 	// +2 for extra chars, + 1 for null char \0
-	char *RegNameNew = malloc(sizeof(char) * (strLn + 2 + 1));
+	char *RegNameNew = cs_mem_malloc(sizeof(char) * (strLn + 2 + 1));
 	int index = 0, i;
 	for (i = 0; i < (strLn + 2); i++){
 		if(RegName[i] != '.'){
@@ -2513,7 +2513,7 @@ static void printMatrixTileVector(MCInst *MI, unsigned OpNum, SStream *O, bool I
 		MI->flat_insn->detail->arm64.operands[MI->flat_insn->detail->arm64.op_count].reg = Reg;
 		MI->flat_insn->detail->arm64.op_count++;
 	}
-	free(RegNameNew);
+	cs_mem_free(RegNameNew);
 }
 
 static const unsigned MatrixZADRegisterTable[] = {


### PR DESCRIPTION
Where new code started using `malloc()` and `free()` directly instead of
going through the cs_mem_* functions.