### PR TITLE
Makefile: fix for <10.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,8 +285,7 @@ endif
 API_MAJOR=$(shell echo `grep -e CS_API_MAJOR include/capstone/capstone.h | grep -v = | awk '{print $$3}'` | awk '{print $$1}')
 VERSION_EXT =
 
-IS_APPLE := $(shell $(CC) -dM -E - < /dev/null 2> /dev/null | grep __apple_build_version__ | wc -l | tr -d " ")
-ifeq ($(IS_APPLE),1)
+ifeq ($(OS),Darwin)
 # on MacOS, do not build in Universal format by default
 MACOS_UNIVERSAL ?= no
 ifeq ($(MACOS_UNIVERSAL),yes)


### PR DESCRIPTION
I do not really get why such a complicated expression is used, while in the same makefile `ifeq ($(OS),Darwin)` is used earlier for the same purpose, but `IS_APPLE :=` fails on <10.7 and breaks the build. `ifeq ($(OS),Darwin)` works fine both on new macOS and 10.6.8.