### PR TITLE
Add `CMAKE_EXPORT_COMPILE_COMMANDS` to cmake build doc

### DIFF
--- a/COMPILE_CMAKE.TXT
+++ b/COMPILE_CMAKE.TXT
@@ -72,6 +72,7 @@ Get CMake for free from http://www.cmake.org.
     This last command is also where you can pass additional CMake configuration flags
     using `-D<key>=<value>`.
     For a debug build add `-DCMAKE_BUILD_TYPE=Debug`.
+    To export `compile_commands.json` add `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`.
     
     Then to build use:
     


### PR DESCRIPTION
This adds the `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` to the `cmake` build instructions. I think it is a commonly wanted option since `compile_commands.json` is used by `clangd`. So people who work on the code possibly want this.

Also this PR renames the file from `debug_build_docs` to `COMPILE_CMAKE.TXT`. Because I accidentally renamed it in the last commit.