### PR TITLE
arch/PowerPC: fix uninitialized read of insn->mnemonic in PPC_post_printer

### DIFF
--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -89,6 +89,12 @@ jobs:
         python cstest_report.py -D -t build/cstest -d ../MC;
         python cstest_report.py -D -t build/cstest -f issues.cs; cd ..;
 
+    - name: test_ppc_iter_detail
+      shell: 'script -q -e -c "bash -e {0}"'
+      run: |
+        export LD_LIBRARY_PATH="${PWD}:${LD_LIBRARY_PATH:-}"
+        if [ -x build/test_ppc_iter_detail ]; then ./build/test_ppc_iter_detail; else ./tests/test_ppc_iter_detail; fi
+
   Windows:
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.name }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,7 +298,7 @@ if(CAPSTONE_PPC_SUPPORT)
         arch/PowerPC/PPCGenRegisterInfo.inc
         arch/PowerPC/PPCGenInstrInfo.inc
     )
-    set(TEST_SOURCES ${TEST_SOURCES} test_ppc.c)
+    set(TEST_SOURCES ${TEST_SOURCES} test_ppc.c test_ppc_iter_detail.c)
 endif()
 
 if(CAPSTONE_X86_SUPPORT)

--- a/arch/PowerPC/PPCInstPrinter.c
+++ b/arch/PowerPC/PPCInstPrinter.c
@@ -79,14 +79,16 @@ void PPC_post_printer(csh ud, cs_insn *insn, char *insn_asm, MCInst *mci)
 	if (((cs_struct *)ud)->detail != CS_OPT_ON)
 		return;
 
-	// check if this insn has branch hint
-	if (strrchr(insn->mnemonic, '+') != NULL && !strstr(insn_asm, ".+")) {
-		insn->detail->ppc.bh = PPC_BH_PLUS;
-	} else if (strrchr(insn->mnemonic, '-') != NULL) {
-		insn->detail->ppc.bh = PPC_BH_MINUS;
-	}
+	// insn->mnemonic is not filled yet; the record-form '.' and the branch
+	// hint '+'/'-' are always the last char of the mnemonic token of insn_asm
+	size_t n = strcspn(insn_asm, " \t");
+	char c = n ? insn_asm[n - 1] : 0;
 
-	if (strrchr(insn->mnemonic, '.') != NULL) {
+	if (c == '+') {
+		insn->detail->ppc.bh = PPC_BH_PLUS;
+	} else if (c == '-') {
+		insn->detail->ppc.bh = PPC_BH_MINUS;
+	} else if (c == '.') {
 		insn->detail->ppc.update_cr0 = true;
 	}
 }

--- a/cs.c
+++ b/cs.c
@@ -581,6 +581,9 @@ static void fill_insn(struct cs_struct *handle, cs_insn *insn, char *buffer, MCI
 	// we might skip some redundant bytes in front in the case of X86
 	memcpy(insn->bytes, code + insn->size - copy_size, copy_size);
 	insn->op_str[0] = '\0';
+	// mnemonic is filled below, after the post printer runs: post printers
+	// must derive any checks from insn_asm, never from insn->mnemonic
+	insn->mnemonic[0] = '\0';
 	insn->size = copy_size;
 
 	// alias instruction might have ID saved in OpcodePub

--- a/suite/cstest/issues.cs
+++ b/suite/cstest/issues.cs
@@ -1118,3 +1118,15 @@
 !# MOVSXD r16, m32 (memory form, 0x66 prefix)
 !# CS_ARCH_X86, CS_MODE_64, CS_OPT_DETAIL
 0x0: 0x66, 0x63, 0x20 == movsxd sp, dword ptr [rax]
+
+!# issue PPC record form sets Update-CR0
+!# CS_ARCH_PPC, CS_MODE_64 | CS_MODE_BIG_ENDIAN, CS_OPT_DETAIL
+0x7c,0x85,0x32,0x15 == add. r4, r5, r6 ; Update-CR0: True
+
+!# issue PPC branch hint plus
+!# CS_ARCH_PPC, CS_MODE_64 | CS_MODE_BIG_ENDIAN, CS_OPT_DETAIL
+0x40,0xe2,0x00,0x10 == bne+ 0x10 ; Branch hint: 1
+
+!# issue PPC branch hint minus
+!# CS_ARCH_PPC, CS_MODE_64 | CS_MODE_BIG_ENDIAN, CS_OPT_DETAIL
+0x40,0xc2,0x00,0x10 == bne- 0x10 ; Branch hint: 2

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -84,6 +84,7 @@ endif
 ifneq (,$(findstring powerpc,$(CAPSTONE_ARCHS)))
 CFLAGS += -DCAPSTONE_HAS_POWERPC
 SOURCES += test_ppc.c
+SOURCES += test_ppc_iter_detail.c
 endif
 ifneq (,$(findstring sparc,$(CAPSTONE_ARCHS)))
 CFLAGS += -DCAPSTONE_HAS_SPARC

--- a/tests/test_ppc_iter_detail.c
+++ b/tests/test_ppc_iter_detail.c
@@ -1,0 +1,90 @@
+/* Capstone Disassembly Engine */
+/* By phix33, 2026 */
+
+// Regression test: update_cr0 and bh (branch hint) must be derived from the
+// current instruction only. PPC_post_printer used to read insn->mnemonic,
+// which the alias early-return paths in PPC_printInst (mr, slwi/srwi, sldi,
+// dcbt/dcbtst, dcbf) never fill before it runs. When one cs_insn buffer is
+// reused across cs_disasm_iter() calls - the documented usage pattern - those
+// aliases inherited update_cr0/bh from the previously decoded instruction.
+
+#include <stdio.h>
+
+#include <capstone/platform.h>
+#include <capstone/capstone.h>
+
+struct step {
+	const char *code;	// 4 bytes, big-endian
+	const char *asm_text;
+	bool update_cr0;
+	ppc_bh bh;
+};
+
+// Each alias is decoded right after an instruction that legitimately sets
+// update_cr0 or a branch hint, into the same reused cs_insn.
+static const struct step steps[] = {
+	{ "\x7c\x85\x32\x15", "add. r4, r5, r6", true, PPC_BH_INVALID },
+	{ "\x7c\x29\x0b\x78", "mr r9, r1", false, PPC_BH_INVALID },
+	{ "\x7c\x85\x32\x15", "add. r4, r5, r6", true, PPC_BH_INVALID },
+	{ "\x54\xa4\x18\x38", "slwi r4, r5, 3", false, PPC_BH_INVALID },
+	{ "\x7c\x85\x32\x15", "add. r4, r5, r6", true, PPC_BH_INVALID },
+	{ "\x78\xa4\x1f\x24", "sldi r4, r5, 3", false, PPC_BH_INVALID },
+	{ "\x7c\x85\x32\x15", "add. r4, r5, r6", true, PPC_BH_INVALID },
+	{ "\x7c\x04\x2a\x2c", "dcbt r4, r5", false, PPC_BH_INVALID },
+	{ "\x7c\x85\x32\x15", "add. r4, r5, r6", true, PPC_BH_INVALID },
+	{ "\x7c\x04\x28\xac", "dcbf r4, r5", false, PPC_BH_INVALID },
+	// non-alias path after a record form: was already correct
+	{ "\x7c\x85\x32\x15", "add. r4, r5, r6", true, PPC_BH_INVALID },
+	{ "\x7c\x85\x32\x14", "add r4, r5, r6", false, PPC_BH_INVALID },
+	// branch hints must not leak into the aliases either
+	{ "\x40\xe2\x00\x10", "bne+ 0x1010", false, PPC_BH_PLUS },
+	{ "\x7c\x29\x0b\x78", "mr r9, r1", false, PPC_BH_INVALID },
+	{ "\x40\xc2\x00\x10", "bne- 0x1010", false, PPC_BH_MINUS },
+	{ "\x7c\x04\x2a\x2c", "dcbt r4, r5", false, PPC_BH_INVALID },
+};
+
+int main(void)
+{
+	csh handle;
+	cs_insn *insn;
+	int i, errors = 0;
+
+	if (cs_open(CS_ARCH_PPC, CS_MODE_64 | CS_MODE_BIG_ENDIAN, &handle) != CS_ERR_OK) {
+		printf("ERROR: Failed to initialize engine!\n");
+		return 1;
+	}
+	cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
+
+	insn = cs_malloc(handle);
+
+	for (i = 0; i < (int)(sizeof(steps) / sizeof(steps[0])); i++) {
+		const uint8_t *code = (const uint8_t *)steps[i].code;
+		size_t size = 4;
+		uint64_t address = 0x1000;
+
+		if (!cs_disasm_iter(handle, &code, &size, &address, insn)) {
+			printf("ERROR: failed to decode '%s'\n", steps[i].asm_text);
+			errors++;
+			continue;
+		}
+
+		bool ok = insn->detail->ppc.update_cr0 == steps[i].update_cr0 &&
+			insn->detail->ppc.bh == steps[i].bh;
+		printf("%s\t%s: update_cr0=%u (expected %u), bh=%u (expected %u)\n",
+				ok ? "OK  " : "FAIL", steps[i].asm_text,
+				insn->detail->ppc.update_cr0, steps[i].update_cr0,
+				insn->detail->ppc.bh, steps[i].bh);
+		if (!ok)
+			errors++;
+	}
+
+	cs_free(insn, 1);
+	cs_close(&handle);
+
+	if (errors) {
+		printf("%d test(s) failed\n", errors);
+		return 1;
+	}
+	printf("all tests passed\n");
+	return 0;
+}


### PR DESCRIPTION
**Your checklist for this pull request**
- [X] I've documented or updated the documentation of every API function and struct this PR changes.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

PPC_post_printer() derives update_cr0 and bh from insn->mnemonic, which is not filled at that point: fill_insn() in cs.c invokes the post printer before copying the mnemonic out of the printed buffer, so reading insn->mnemonic there is wrong by construction. It normally works only because PPC_printInst() copies the first output token into flat_insn->mnemonic — but five alias paths (mr, slwi/srwi, sldi, dcbt/dcbtst, dcbf) return early and skip that copy, so the post-printer reads memory the engine never wrote.

With cs_disasm_iter() (which reuses one cs_insn by design) the effect is deterministic: decoding add. then mr reports mr with update_cr0 = true; decoding bne+ then mr gives mr a branch hint. With cs_disasm() the result depends on heap contents (valgrind flags the read). Found via a randomly failing radare2 test; radare2 currently carries a workaround (radare2@2646d7712a).

Fix, in two parts:
- PPC_post_printer() tests the last character of the mnemonic token of insn_asm (bounded by strcspn(insn_asm, " \t")), which always holds the current instruction's text. On PPC the record-form . and the branch hint +/- are always the final character of the mnemonic — verified across all 1666 asm strings in PPCGenAsmWriter.inc and every alias/hint printer (printAliasBcc, printPredicateOperand "pm", printATBitsAsHint all append the hint last). This also retires the old strstr(insn_asm, ".+") guard, which only ever defended against a + inside a PC-relative operand — out of reach once the check is confined to the mnemonic token.
- fill_insn() now clears insn->mnemonic before invoking the post printer, with a comment stating the contract (post printers must parse insn_asm, not read insn->mnemonic), so no post printer can depend on stale contents again. No other arch's post printer reads insn->mnemonic/op_str (checked AArch64, ARM, X86, Sparc, SystemZ, TMS320C64x, XCore) — PPC was the only offender.

A fully structured derivation (no text parsing at all) was considered and deliberately not done here: update_cr0 from the register-write map (cs_reg_write(CR0) in PPC_get_insn_id) is not equivalent to the printed-dot semantics — FP record forms write CR1 (fadd.) and Altivec record forms write CR6 (vcmpequb.), so it would silently change the reported update_cr0 for those; and the branch hint is emitted by four independent printer mechanisms in v5, so there is no single place to set bh structurally. next is not affected either way (post_printer is NULL there and fill_insn() zeroes the mnemonic).

**Test plan**

tests/test_ppc_iter_detail.c (self-checking, runs under ctest; 7/16 checks fail before the fix, all pass after) plus three issues.cs entries pinning the preserved positives (add. sets Update-CR0, bne+/bne- report hints). Existing PPC issues.cs and suite/MC/PowerPC pass unchanged, and the full ctest suite (all arches) passes, confirming the fill_insn() change is a no-op everywhere else.

**Closing issues**

"None".

