### PR TITLE
AArch64: Fix diet-mode NULL deref in printMatrixTileVector

### DIFF
--- a/arch/AArch64/AArch64InstPrinter.c
+++ b/arch/AArch64/AArch64InstPrinter.c
@@ -965,6 +965,10 @@ DEFINE_printMatrix(0);
 		const char *RegName = getRegisterName(MCOperand_getReg(RegOp), \
 						      AArch64_NoRegAltName); \
 \
+		/* Diet builds have no register-name table; skip printing. */ \
+		if (!RegName) \
+			return; \
+\
 		unsigned buf_len = strlen(RegName) + 1; \
 		char *Base = cs_mem_calloc(1, buf_len); \
 		memcpy(Base, RegName, buf_len); \


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

In `CAPSTONE_DIET` builds, `getRegisterName()` returns `NULL` because the register-name string table is compiled out (see the `#else return NULL;` branch in `arch/AArch64/AArch64GenAsmWriter.inc`). Every other AArch64 printer helper feeds that `NULL` into `SStream_concat0()`, which is a no-op on `NULL` under `CAPSTONE_DIET` (`SStream.c`). `printMatrixTileVector` is the outlier: it calls `strlen(RegName) + 1` directly to size a scratch buffer, so the `NULL` result causes SIGSEGV inside `strlen`.

Early-return after `AArch64_add_cs_detail_1()` when `RegName` is `NULL`, so detail-mode users still get the operand recorded and only the (unused, in diet builds) string-building work is skipped.

Reproducer: 4 bytes `c0 c0 c0 c0`. Not a real AArch64 instruction, but the decoder maps it to an SME (Scalable Matrix Extension) alias whose printer exercises `printMatrixTileVector_1`.

```c
#include <capstone/capstone.h>
int main(void) {
    csh h; cs_insn *i = NULL;
    static const unsigned char code[] = { 0xc0, 0xc0, 0xc0, 0xc0 };
    cs_open(CS_ARCH_AARCH64, CS_MODE_LITTLE_ENDIAN, &h);
    cs_disasm(h, code, sizeof(code), 0x1000, 0, &i); /* SIGSEGV before fix */
    return 0;
}
```

Build (diet, aarch64-only):

```
make CAPSTONE_ARCHS=aarch64 CAPSTONE_DIET=yes CAPSTONE_BUILD_CORE_ONLY=yes \
     CAPSTONE_STATIC=yes CAPSTONE_SHARED=no
```

Stack before fix:

```
__strlen_asimd
printMatrixTileVector_1
printInst
AArch64_printer
cs_disasm
```

**Test plan**

- Non-diet builds: unaffected (`getRegisterName` returns a real string, code path unchanged).
- Diet builds: PoC above and the three other 16/43/54/80-byte crashers originally surfaced by libFuzzer all now exit cleanly.
- Ran a quick 10-minute fuzzing (~66M disassembly paths) and no other issue came up (but a longer fuzzing session should be done).

**Closing issues**

closes https://github.com/capstone-engine/capstone/issues/3014
