### PR TITLE
x86: use effective address size for the loop counter register

### DIFF
--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -957,6 +957,7 @@ void X86_get_insn_id(cs_struct *h, cs_insn *insn, unsigned int id)
 			case X86_INS_LOOP:
 			case X86_INS_LOOPE:
 			case X86_INS_LOOPNE:
+				// The instruction pointer register follows the mode.
 				switch (h->mode) {
 				default:
 					break;
@@ -969,14 +970,6 @@ void X86_get_insn_id(cs_struct *h, cs_insn *insn, unsigned int id)
 						insn->detail->regs_write,
 						insn->detail->regs_write_count,
 						X86_REG_EIP, X86_REG_IP);
-					arr_replace(
-						insn->detail->regs_read,
-						insn->detail->regs_read_count,
-						X86_REG_ECX, X86_REG_CX);
-					arr_replace(
-						insn->detail->regs_write,
-						insn->detail->regs_write_count,
-						X86_REG_ECX, X86_REG_CX);
 					break;
 				case CS_MODE_64:
 					arr_replace(
@@ -987,6 +980,20 @@ void X86_get_insn_id(cs_struct *h, cs_insn *insn, unsigned int id)
 						insn->detail->regs_write,
 						insn->detail->regs_write_count,
 						X86_REG_EIP, X86_REG_RIP);
+					break;
+				}
+				// The loop counter register follows the effective address
+				// size, which a 0x67 address-size prefix can override.
+				if (insn->detail->x86.addr_size == 2) {
+					arr_replace(
+						insn->detail->regs_read,
+						insn->detail->regs_read_count,
+						X86_REG_ECX, X86_REG_CX);
+					arr_replace(
+						insn->detail->regs_write,
+						insn->detail->regs_write_count,
+						X86_REG_ECX, X86_REG_CX);
+				} else if (insn->detail->x86.addr_size == 8) {
 					arr_replace(
 						insn->detail->regs_read,
 						insn->detail->regs_read_count,
@@ -995,7 +1002,6 @@ void X86_get_insn_id(cs_struct *h, cs_insn *insn, unsigned int id)
 						insn->detail->regs_write,
 						insn->detail->regs_write_count,
 						X86_REG_ECX, X86_REG_RCX);
-					break;
 				}
 			}
 

--- a/tests/details/x86.yaml
+++ b/tests/details/x86.yaml
@@ -6053,8 +6053,8 @@ test_cases:
           x86:
             prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_ADDRSIZE ]
             opcode: [ 0xe2, 0x00, 0x00, 0x00 ]
-          regs_read: [ rip, rcx ]
-          regs_write: [ rip, rcx ]      # BUG: should be ecx
+          regs_read: [ rip, ecx ]
+          regs_write: [ rip, ecx ]
       -
         asm_text: "loope 0x34"
         details:
@@ -6081,8 +6081,8 @@ test_cases:
             prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_ADDRSIZE ]
             opcode: [ 0xe1, 0x00, 0x00, 0x00 ]
             eflags: [ X86_EFLAGS_TEST_ZF ]
-          regs_read: [ rip, rcx, rflags ]
-          regs_write: [ rip, rcx ]      # BUG: should be ecx
+          regs_read: [ rip, ecx, rflags ]
+          regs_write: [ rip, ecx ]
       -
         asm_text: "loopne 0x34"
         details:
@@ -6109,8 +6109,8 @@ test_cases:
             prefix: [ X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_0, X86_PREFIX_ADDRSIZE ]
             opcode: [ 0xe0, 0x00, 0x00, 0x00 ]
             eflags: [ X86_EFLAGS_TEST_ZF ]
-          regs_read: [ rip, rcx, rflags ]
-          regs_write: [ rip, rcx ]      # BUG: should be ecx
+          regs_read: [ rip, ecx, rflags ]
+          regs_write: [ rip, ecx ]
 
   -
     input:


### PR DESCRIPTION
Fixes #2823.

The implicit counter register of `loop`/`loope`/`loopne` (and its `regs_read`/`regs_write` detail) was selected from the CPU mode alone (CX/ECX/RCX for 16/32/64-bit), ignoring a `0x67` address-size prefix. The loop counter register is chosen by the effective *address* size, so `67 e2 c2` (`loop`) in 64-bit mode reported `rcx` instead of `ecx`.

This selects the counter register from the effective address size (`insn->detail->x86.addr_size`, which the `0x67` prefix already accounts for), while the instruction-pointer register keeps following the mode.

Before:
```
$ cstool -d x64 67e2c2 | grep 'Registers read'
	Registers read: rip rcx
```
After:
```
$ cstool -d x64 67e2c2 | grep 'Registers read'
	Registers read: rip ecx
```

The fix also corrects the 16-bit and 32-bit cases where `0x67` changes the effective address size (16-bit + `0x67` → ECX, 32-bit + `0x67` → CX). The three affected `tests/details/x86.yaml` fixtures (which carried `# BUG: should be ecx` markers) are updated to `ecx`, and `cstest` passes (40/40 cases).
