### PR TITLE
Add MSAN build option to CMakeLists.txt

### DIFF
--- a/.github/workflows/CITest.yml
+++ b/.github/workflows/CITest.yml
@@ -27,6 +27,7 @@ env:
   UBSAN_OPTIONS: "halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1"
   ASAN_OPTIONS: "halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1"
   LSAN_OPTIONS: "halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1"
+  MSAN_OPTIONS: "halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1"
 
 jobs:
   Linux:
@@ -42,7 +43,9 @@ jobs:
               arch: x64,
               build-system: 'make',
               diet-build: 'OFF',
-              enable-asan: 'OFF'
+              enable-asan: 'OFF',
+              enable-msan: 'OFF',
+              cc: 'gcc'
             }
           - {
               name: 'ubuntu-22.04 x64 cmake',
@@ -51,6 +54,8 @@ jobs:
               build-system: 'cmake',
               diet-build: 'OFF',
               enable-asan: 'OFF',
+              enable-msan: 'OFF',
+              cc: 'gcc',
               build_type: 'Debug'
             }
           - {
@@ -60,6 +65,8 @@ jobs:
               build-system: 'cmake',
               diet-build: 'OFF',
               enable-asan: 'OFF',
+              enable-msan: 'OFF',
+              cc: 'gcc',
               build_type: 'Debug',
               build_options: '-DCAPSTONE_ASSERTION_WARNINGS=ON'
             }
@@ -70,6 +77,8 @@ jobs:
               build-system: 'cmake',
               diet-build: 'OFF',
               enable-asan: 'OFF',
+              enable-msan: 'OFF',
+              cc: 'gcc',
               build_type: 'Release',
               build_options: '-DCAPSTONE_ASSERTION_WARNINGS=OFF'
             }
@@ -80,6 +89,8 @@ jobs:
               build-system: 'cmake',
               diet-build: 'OFF',
               enable-asan: 'OFF',
+              enable-msan: 'OFF',
+              cc: 'gcc',
               build_type: 'Release',
               build_options: '-DCAPSTONE_ASSERTION_WARNINGS=ON'
             }
@@ -90,6 +101,8 @@ jobs:
               build-system: 'cmake',
               diet-build: 'OFF',
               enable-asan: 'ON',
+              enable-msan: 'OFF',
+              cc: 'gcc',
               build_type: 'Debug'
             }
 
@@ -117,15 +130,33 @@ jobs:
       if: startsWith(matrix.config.build-system, 'cmake')
       env:
         asan: ${{ matrix.config.enable-asan }}
+        msan: ${{ matrix.config.enable-msan }}
+        compiler: ${{ matrix.config.cc }}
         build_option: ${{ matrix.config.build_option }}
         build_type: ${{ matrix.config.build_type }}
       run: |
         mkdir build && cd build
         # build static library
-        cmake -DCMAKE_BUILD_TYPE=${build_type} -DCAPSTONE_INSTALL=1 -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_ASAN=${asan} -DCAPSTONE_BUILD_DIET=${diet_build} ${build_option} ..
+        cmake \
+          -DCMAKE_BUILD_TYPE=${build_type} \
+          -DCAPSTONE_INSTALL=1 \
+          -DCMAKE_C_COMPILER=${compiler} \
+          -DCMAKE_INSTALL_PREFIX=/usr \
+          -DENABLE_ASAN=${asan} \
+          -DENABLE_MSAN=${msan} \
+          -DCAPSTONE_BUILD_DIET=${diet_build} ${build_option} ..
         cmake --build . --config ${build_type}
+
         # build shared library
-        cmake -DCMAKE_BUILD_TYPE=${build_type} -DCAPSTONE_INSTALL=1 -DCAPSTONE_BUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_PREFIX=/usr -DCAPSTONE_BUILD_CSTEST=ON -DENABLE_ASAN=${asan} ${build_option} ..
+        cmake \
+          -DCMAKE_BUILD_TYPE=${build_type} \
+          -DCAPSTONE_INSTALL=1 \
+          -DCAPSTONE_BUILD_SHARED_LIBS=1 \
+          -DCMAKE_C_COMPILER=${compiler} \
+          -DCMAKE_INSTALL_PREFIX=/usr \
+          -DCAPSTONE_BUILD_CSTEST=ON \
+          -DENABLE_ASAN=${asan} \
+          -DENABLE_MSAN=${msan} ${build_option} ..
         sudo cmake --build . --config ${build_type} --target install
 
     - name: Lower number of KASL randomized address bits
@@ -183,7 +214,7 @@ jobs:
         ctest --test-dir build --output-on-failure -R legacy*
 
     - name: Valgrind cstest
-      if: startsWith(matrix.config.build-system, 'cmake') && startsWith(matrix.config.enable-asan, 'OFF')
+      if: startsWith(matrix.config.build-system, 'cmake') && startsWith(matrix.config.enable-asan, 'OFF') && startsWith(matrix.config.enable-msan, 'OFF')
       run: |
         sudo apt-get -y update
         sudo apt-get -y install valgrind

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,10 +82,15 @@ option(CAPSTONE_DEBUG "Whether to enable extra debug assertions (enabled with CM
 option(CAPSTONE_ASSERTION_WARNINGS "Disables some asserts and warns instead when hit. Does not disable all asserts." OFF)
 option(CAPSTONE_INSTALL "Generate install target" ${PROJECT_IS_TOP_LEVEL})
 option(ENABLE_ASAN "Enable address sanitizer" OFF)
+option(ENABLE_MSAN "Enable memory sanitizer" OFF)
 option(ENABLE_COVERAGE "Enable test coverage" OFF)
 
 if (NOT CAPSTONE_BUILD_SHARED_LIBS AND NOT CAPSTONE_BUILD_STATIC_LIBS)
     FATAL_ERROR("CAPSTONE_BUILD_SHARED_LIBS and CAPSTONE_BUILD_STATIC_LIBS are both unset. Nothing to build.")
+endif()
+
+if (ENABLE_ASAN AND ENABLE_MSAN)
+    message(FATAL_ERROR "ASAN and MSAN cannot be enabled at the same time. They are not compatible.")
 endif()
 
 if (ENABLE_ASAN)
@@ -93,6 +98,16 @@ if (ENABLE_ASAN)
     add_definitions(-DASAN_ENABLED)
     add_compile_options(-fsanitize=address,undefined)
     add_link_options(-fsanitize=address,undefined)
+endif()
+
+if (ENABLE_MSAN)
+    message("Enabling MSAN")
+    if (NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")
+        message(WARNING "CC compiler is NOT Clang. MSAN maybe isn't supported.")
+    endif()
+    add_definitions(-DMSAN_ENABLED)
+    add_compile_options(-fsanitize=memory)
+    add_link_options(-fsanitize=memory)
 endif()
 
 if (ENABLE_COVERAGE)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Adds an option to build Capstone with MSAN.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

It is currently not tested. It is only a convenience feature.

Mostly because `cstest` will fail with MSAN, because somewhere in libcyaml some pointer was marked as uninitialized (very very likely a false positive, because valgrind doesn't fail).

There are still tests for uninitialized memory usage with valgrind (https://github.com/capstone-engine/capstone/pull/3030).

So this feature is only useful as a one flag setup to compile with MSAN.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
