### PR TITLE
x86: fix VMOVUPS memory operand access

### DIFF
--- a/arch/X86/X86MappingInsnOp.inc
+++ b/arch/X86/X86MappingInsnOp.inc
@@ -39495,7 +39495,7 @@
 
 {	/* X86_VMOVUPSmr, X86_INS_VMOVUPS: vmovups */
 	0,
-	{ CS_AC_READ, CS_AC_READ, 0 }
+	{ CS_AC_WRITE, CS_AC_READ, 0 }
 },
 
 {	/* X86_VMOVUPSrm, X86_INS_VMOVUPS: vmovups */

--- a/tests/issues/issues.yaml
+++ b/tests/issues/issues.yaml
@@ -1,6 +1,26 @@
 test_cases:
   -
     input:
+      name: "issue 2900 vmovups memory destination access"
+      bytes: [ 0xc5,0xf8,0x11,0x28 ]
+      arch: "CS_ARCH_X86"
+      options: [ CS_MODE_64, CS_OPT_DETAIL ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "vmovups xmmword ptr [rax], xmm5"
+        details:
+          x86:
+            operands:
+              -
+                type: X86_OP_MEM
+                access: CS_AC_WRITE
+              -
+                type: X86_OP_REG
+                access: CS_AC_READ
+  -
+    input:
       name: "issue 2323 eBPF bswap16 instruction"
       bytes: [ 0xd7,0x53,0x3f,0x0c,0x10,0x00,0x00,0x00 ]
       arch: "CS_ARCH_BPF"


### PR DESCRIPTION
**Your checklist for this pull request**

- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

The VEX.128 memory-store form of VMOVUPS incorrectly marks its memory destination operand as CS_AC_READ.
This changes the first operand access of X86_VMOVUPSmr to CS_AC_WRITE, while preserving CS_AC_READ for the source register. The bytes reported in issue #2900, C5 F8 11 28, decode to vmovups xmmword ptr [rax], xmm5 because the ModR/M byte selects xmm5. 

**Test plan**

Added a regression test to tests/issues/issues.yaml which verifies that:
- the memory destination has CS_AC_WRITE;
- the source XMM register has CS_AC_READ.

All tests passed

**Closing issues**
Closes #2900