### PR TITLE
alpha: sign-extend memory-format displacement

### DIFF
--- a/arch/Alpha/AlphaGenDisassemblerTables.inc
+++ b/arch/Alpha/AlphaGenDisassemblerTables.inc
@@ -733,7 +733,7 @@ static DecodeStatus fname(DecodeStatus S, unsigned Idx, InsnType insn, MCInst *M
     tmp = fieldname(insn, 21, 5); \
     if (DecodeGPRCRegisterClass(MI, tmp, Address, Decoder) == MCDisassembler_Fail) { return MCDisassembler_Fail; } \
     tmp = fieldname(insn, 0, 16); \
-    MCOperand_CreateImm0(MI, tmp); \
+    MCOperand_CreateImm0(MI, (int16_t)tmp); \
     tmp = fieldname(insn, 16, 5); \
     if (DecodeGPRCRegisterClass(MI, tmp, Address, Decoder) == MCDisassembler_Fail) { return MCDisassembler_Fail; } \
     return S; \
@@ -871,7 +871,7 @@ static DecodeStatus fname(DecodeStatus S, unsigned Idx, InsnType insn, MCInst *M
     tmp = fieldname(insn, 21, 5); \
     if (DecodeF4RCRegisterClass(MI, tmp, Address, Decoder) == MCDisassembler_Fail) { return MCDisassembler_Fail; } \
     tmp = fieldname(insn, 0, 16); \
-    MCOperand_CreateImm0(MI, tmp); \
+    MCOperand_CreateImm0(MI, (int16_t)tmp); \
     tmp = fieldname(insn, 16, 5); \
     if (DecodeGPRCRegisterClass(MI, tmp, Address, Decoder) == MCDisassembler_Fail) { return MCDisassembler_Fail; } \
     return S; \
@@ -879,7 +879,7 @@ static DecodeStatus fname(DecodeStatus S, unsigned Idx, InsnType insn, MCInst *M
     tmp = fieldname(insn, 21, 5); \
     if (DecodeF8RCRegisterClass(MI, tmp, Address, Decoder) == MCDisassembler_Fail) { return MCDisassembler_Fail; } \
     tmp = fieldname(insn, 0, 16); \
-    MCOperand_CreateImm0(MI, tmp); \
+    MCOperand_CreateImm0(MI, (int16_t)tmp); \
     tmp = fieldname(insn, 16, 5); \
     if (DecodeGPRCRegisterClass(MI, tmp, Address, Decoder) == MCDisassembler_Fail) { return MCDisassembler_Fail; } \
     return S; \
@@ -889,7 +889,7 @@ static DecodeStatus fname(DecodeStatus S, unsigned Idx, InsnType insn, MCInst *M
     tmp = fieldname(insn, 21, 5); \
     if (DecodeGPRCRegisterClass(MI, tmp, Address, Decoder) == MCDisassembler_Fail) { return MCDisassembler_Fail; } \
     tmp = fieldname(insn, 0, 16); \
-    MCOperand_CreateImm0(MI, tmp); \
+    MCOperand_CreateImm0(MI, (int16_t)tmp); \
     tmp = fieldname(insn, 16, 5); \
     if (DecodeGPRCRegisterClass(MI, tmp, Address, Decoder) == MCDisassembler_Fail) { return MCDisassembler_Fail; } \
     return S; \

--- a/suite/auto-sync/inc_patches/Alpha/01_mem_disp_sign_extend.patch
+++ b/suite/auto-sync/inc_patches/Alpha/01_mem_disp_sign_extend.patch
@@ -1,0 +1,40 @@
+diff --git a/arch/Alpha/AlphaGenDisassemblerTables.inc b/arch/Alpha/AlphaGenDisassemblerTables.inc
+index a35b974..6441634 100644
+--- a/arch/Alpha/AlphaGenDisassemblerTables.inc
++++ b/arch/Alpha/AlphaGenDisassemblerTables.inc
+@@ -733,7 +733,7 @@ static DecodeStatus fname(DecodeStatus S, unsigned Idx, InsnType insn, MCInst *M
+     tmp = fieldname(insn, 21, 5); \
+     if (DecodeGPRCRegisterClass(MI, tmp, Address, Decoder) == MCDisassembler_Fail) { return MCDisassembler_Fail; } \
+     tmp = fieldname(insn, 0, 16); \
+-    MCOperand_CreateImm0(MI, tmp); \
++    MCOperand_CreateImm0(MI, (int16_t)tmp); \
+     tmp = fieldname(insn, 16, 5); \
+     if (DecodeGPRCRegisterClass(MI, tmp, Address, Decoder) == MCDisassembler_Fail) { return MCDisassembler_Fail; } \
+     return S; \
+@@ -871,7 +871,7 @@ static DecodeStatus fname(DecodeStatus S, unsigned Idx, InsnType insn, MCInst *M
+     tmp = fieldname(insn, 21, 5); \
+     if (DecodeF4RCRegisterClass(MI, tmp, Address, Decoder) == MCDisassembler_Fail) { return MCDisassembler_Fail; } \
+     tmp = fieldname(insn, 0, 16); \
+-    MCOperand_CreateImm0(MI, tmp); \
++    MCOperand_CreateImm0(MI, (int16_t)tmp); \
+     tmp = fieldname(insn, 16, 5); \
+     if (DecodeGPRCRegisterClass(MI, tmp, Address, Decoder) == MCDisassembler_Fail) { return MCDisassembler_Fail; } \
+     return S; \
+@@ -879,7 +879,7 @@ static DecodeStatus fname(DecodeStatus S, unsigned Idx, InsnType insn, MCInst *M
+     tmp = fieldname(insn, 21, 5); \
+     if (DecodeF8RCRegisterClass(MI, tmp, Address, Decoder) == MCDisassembler_Fail) { return MCDisassembler_Fail; } \
+     tmp = fieldname(insn, 0, 16); \
+-    MCOperand_CreateImm0(MI, tmp); \
++    MCOperand_CreateImm0(MI, (int16_t)tmp); \
+     tmp = fieldname(insn, 16, 5); \
+     if (DecodeGPRCRegisterClass(MI, tmp, Address, Decoder) == MCDisassembler_Fail) { return MCDisassembler_Fail; } \
+     return S; \
+@@ -889,7 +889,7 @@ static DecodeStatus fname(DecodeStatus S, unsigned Idx, InsnType insn, MCInst *M
+     tmp = fieldname(insn, 21, 5); \
+     if (DecodeGPRCRegisterClass(MI, tmp, Address, Decoder) == MCDisassembler_Fail) { return MCDisassembler_Fail; } \
+     tmp = fieldname(insn, 0, 16); \
+-    MCOperand_CreateImm0(MI, tmp); \
++    MCOperand_CreateImm0(MI, (int16_t)tmp); \
+     tmp = fieldname(insn, 16, 5); \
+     if (DecodeGPRCRegisterClass(MI, tmp, Address, Decoder) == MCDisassembler_Fail) { return MCDisassembler_Fail; } \
+     return S; \

--- a/tests/MC/Alpha/insn-alpha.s.yaml
+++ b/tests/MC/Alpha/insn-alpha.s.yaml
@@ -2015,3 +2015,57 @@ test_cases:
       insns:
         -
           asm_text: "rs $1"
+  -
+    input:
+      bytes: [ 0xb0, 0xb0, 0x42, 0x20 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "lda $2,-0x4f50($2)"
+  -
+    input:
+      bytes: [ 0xf0, 0xff, 0x22, 0xa4 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldq $1,-0x10($2)"
+  -
+    input:
+      bytes: [ 0xf0, 0xff, 0x22, 0xb4 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "stq $1,-0x10($2)"
+  -
+    input:
+      bytes: [ 0xff, 0xff, 0x22, 0x88 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "lds $f1,-1($2)"
+  -
+    input:
+      bytes: [ 0xff, 0xff, 0x22, 0x9c ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "stt $f1,-1($2)"
+  -
+    input:
+      bytes: [ 0xf0, 0xff, 0x22, 0xb8 ]
+      arch: "CS_ARCH_ALPHA"
+      options: [ "CS_MODE_LITTLE_ENDIAN" ]
+    expected:
+      insns:
+        -
+          asm_text: "stl_c $1,-0x10($2)"

--- a/tests/details/alpha.yaml
+++ b/tests/details/alpha.yaml
@@ -40,7 +40,7 @@ test_cases:
                 type: ALPHA_OP_REG
                 reg: $29
       -
-        asm_text: "lda $30,0xffd0($30)"
+        asm_text: "lda $30,-0x30($30)"
         details:
           regs_read: [ $30 ]
           regs_write: [ $28, $30 ]
@@ -51,7 +51,7 @@ test_cases:
                 reg: $30
               -
                 type: ALPHA_OP_IMM
-                imm: 0xffd0
+                imm: -0x30
               -
                 type: ALPHA_OP_REG
                 reg: $30
@@ -112,7 +112,7 @@ test_cases:
                 type: ALPHA_OP_REG
                 reg: $29
       -
-        asm_text: "lda $30,0xffd0($30)"
+        asm_text: "lda $30,-0x30($30)"
         details:
           regs_read: [ $30 ]
           regs_write: [ $28, $30 ]
@@ -123,7 +123,7 @@ test_cases:
                 reg: $30
               -
                 type: ALPHA_OP_IMM
-                imm: 0xffd0
+                imm: -0x30
               -
                 type: ALPHA_OP_REG
                 reg: $30

--- a/tests/details/cs_common_details.yaml
+++ b/tests/details/cs_common_details.yaml
@@ -1228,9 +1228,9 @@ test_cases:
           details:
             regs_impl_write: [ $28 ]
         -
-          asm_text: "lda $30,0xffd0($30)"
+          asm_text: "lda $30,-0x30($30)"
           mnemonic: "lda"
-          op_str: "$30,0xffd0($30)"
+          op_str: "$30,-0x30($30)"
           details:
             regs_impl_write: [ $28 ]
         -
@@ -1261,9 +1261,9 @@ test_cases:
           details:
             regs_impl_write: [ $28 ]
         -
-          asm_text: "lda $30,0xffd0($30)"
+          asm_text: "lda $30,-0x30($30)"
           mnemonic: "lda"
-          op_str: "$30,0xffd0($30)"
+          op_str: "$30,-0x30($30)"
           details:
             regs_impl_write: [ $28 ]
         -


### PR DESCRIPTION
**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

The Alpha memory-format instructions (`lda`, the integer loads/stores, the store-conditional forms, and the `lds`/`ldt`/`sts`/`stt` float loads and stores) carry a 16-bit displacement that the ISA treats as signed, but the decoder read it out of the instruction word as a plain unsigned field and never sign-extended it, so any displacement with bit 15 set decoded to a large positive value. `cstool -d alpha 0xb0,0xb0,0x42,0x20` shows it: the offset prints as `0xb0b0` and `operands[1].imm` is `0xb0b0`, where it should be `-20304`. The displacement is read in the shared decode macro at the four memory-format cases (indices 1, 22, 23, 24), each storing `fieldFromInstruction_4(insn, 0, 16)` straight into the operand. Casting that field through `int16_t` at those four sites stores the signed offset, so the same word now decodes to `lda $2,-0x4f50($2)`. Positive displacements are unaffected.

**Test plan**

`cstool -d alpha 0xb0,0xb0,0x42,0x20` now prints `lda $2,-0x4f50($2)` with `operands[1].imm = 0xffffffffffffb0b0`. I added negative-displacement cases to `tests/MC/Alpha/insn-alpha.s.yaml` covering the integer, store-conditional and float-memory forms, and updated the two detail cases in `tests/details/alpha.yaml` and `tests/details/cs_common_details.yaml` that had captured the old unsigned value.

**Closing issues**

closes #3021
