### PR TITLE
PowerPC: Keep BI out of the CTR-only branch predicate

### DIFF
--- a/include/capstone/ppc.h
+++ b/include/capstone/ppc.h
@@ -248,16 +248,18 @@ static inline ppc_pred PPC_get_branch_pred(uint8_t bi, uint8_t bo,
 	if ((get_cr_pred && !TestCR) || (!get_cr_pred && !DecrCTR))
 		return PPC_PRED_INVALID;
 
+	if (!get_cr_pred) {
+		// The CTR condition without the CR-bit condition. BI selects a
+		// CR bit, so it is ignored here whether or not BO also encodes
+		// a CR-bit condition.
+		return PPC_get_no_hint_pred(
+			(ppc_pred)((bo | PPC_BO_TEST_CR) & ~PPC_BO_CR_CMP));
+	}
 	if (TestCR && DecrCTR) {
 		// The CR-bit condition without the CTR condition.
 		unsigned cr_bo_cond = (bo | PPC_BO_DECR_CTR) & ~PPC_BO_CTR_CMP;
-		// The CTR condition without the CR-bit condition.
-		unsigned ctr_bo_cond = (bo | PPC_BO_TEST_CR) & ~PPC_BO_CR_CMP;
-		if (get_cr_pred)
-			return PPC_get_no_hint_pred(
-				(ppc_pred)(((bi % 4) << 5) | cr_bo_cond));
 		return PPC_get_no_hint_pred(
-			(ppc_pred)ctr_bo_cond); // BI is ignored
+			(ppc_pred)(((bi % 4) << 5) | cr_bo_cond));
 	}
 	// BO doesn't need any separation
 	return PPC_get_no_hint_pred((ppc_pred)(((bi % 4) << 5) | bo));

--- a/suite/cstest/include/test_mapping.h
+++ b/suite/cstest/include/test_mapping.h
@@ -1254,6 +1254,7 @@ static const cs_enum_id_map cs_enum_map[] = {
 	{ .str = "PPC_PRED_GT_MINUS", .val = PPC_PRED_GT_MINUS },
 	{ .str = "PPC_PRED_GT_PLUS", .val = PPC_PRED_GT_PLUS },
 	{ .str = "PPC_PRED_GT_RESERVED", .val = PPC_PRED_GT_RESERVED },
+	{ .str = "PPC_PRED_INVALID", .val = PPC_PRED_INVALID },
 	{ .str = "PPC_PRED_LE", .val = PPC_PRED_LE },
 	{ .str = "PPC_PRED_LE_MINUS", .val = PPC_PRED_LE_MINUS },
 	{ .str = "PPC_PRED_LE_PLUS", .val = PPC_PRED_LE_PLUS },

--- a/tests/details/ppc.yaml
+++ b/tests/details/ppc.yaml
@@ -1712,3 +1712,106 @@ test_cases:
                 mem_base: r26
                 mem_offset: r1
                 access: CS_AC_READ
+  -
+    input:
+      # BI selects a CR bit and has no part in the counter predicate, so a
+      # CTR-only BO must decode the same whatever BI holds. bclr is the XL
+      # form, whose BI and BO come out of a different field mask than bc's.
+      bytes: [ 0x42, 0x00, 0x00, 0x10, 0x42, 0x06, 0x00, 0x10, 0x42, 0x46, 0x00, 0x10, 0x4e, 0x06, 0x00, 0x20 ]
+      arch: "ppc"
+      options: [ CS_MODE_BIG_ENDIAN, CS_OPT_DETAIL ]
+      address: 0x1000
+    expected:
+      insns:
+      -
+        asm_text: "bc 0x10, lt, 0x1010"
+        details:
+         ppc:
+            operands:
+              -
+                type: PPC_OP_IMM
+                imm: 0x10
+                access: CS_AC_READ
+              -
+                type: PPC_OP_REG
+                reg: "0"
+                access: CS_AC_READ
+              -
+                type: PPC_OP_IMM
+                imm: 0x1010
+                access: CS_AC_READ
+            bc:
+              bi: 0
+              bi_set: true
+              bo: 16
+              bo_set: true
+              pred_ctr: PPC_PRED_NZ
+      -
+        asm_text: "bc 0x10, 4*cr1+eq, 0x1014"
+        details:
+         ppc:
+            operands:
+              -
+                type: PPC_OP_IMM
+                imm: 0x10
+                access: CS_AC_READ
+              -
+                type: PPC_OP_REG
+                reg: "6"
+                access: CS_AC_READ
+              -
+                type: PPC_OP_IMM
+                imm: 0x1014
+                access: CS_AC_READ
+            bc:
+              bi: 6
+              bi_set: true
+              bo: 16
+              bo_set: true
+              pred_ctr: PPC_PRED_NZ
+      -
+        asm_text: "bc 0x12, 4*cr1+eq, 0x1018"
+        details:
+         ppc:
+            operands:
+              -
+                type: PPC_OP_IMM
+                imm: 0x12
+                access: CS_AC_READ
+              -
+                type: PPC_OP_REG
+                reg: "6"
+                access: CS_AC_READ
+              -
+                type: PPC_OP_IMM
+                imm: 0x1018
+                access: CS_AC_READ
+            bc:
+              bi: 6
+              bi_set: true
+              bo: 18
+              bo_set: true
+              pred_ctr: PPC_PRED_Z
+      -
+        asm_text: "bclr 0x10, 4*cr1+eq, 0"
+        details:
+         ppc:
+            operands:
+              -
+                type: PPC_OP_IMM
+                imm: 0x10
+                access: CS_AC_READ
+              -
+                type: PPC_OP_REG
+                reg: "6"
+                access: CS_AC_READ
+              -
+                type: PPC_OP_IMM
+                imm: 0x0
+                access: CS_AC_READ
+            bc:
+              bi: 6
+              bi_set: true
+              bo: 16
+              bo_set: true
+              pred_ctr: PPC_PRED_NZ

--- a/tests/details/ppc.yaml
+++ b/tests/details/ppc.yaml
@@ -1745,6 +1745,7 @@ test_cases:
               bi_set: true
               bo: 16
               bo_set: true
+              pred_cr: PPC_PRED_INVALID
               pred_ctr: PPC_PRED_NZ
       -
         asm_text: "bc 0x10, 4*cr1+eq, 0x1014"
@@ -1768,6 +1769,7 @@ test_cases:
               bi_set: true
               bo: 16
               bo_set: true
+              pred_cr: PPC_PRED_INVALID
               pred_ctr: PPC_PRED_NZ
       -
         asm_text: "bc 0x12, 4*cr1+eq, 0x1018"
@@ -1791,6 +1793,7 @@ test_cases:
               bi_set: true
               bo: 18
               bo_set: true
+              pred_cr: PPC_PRED_INVALID
               pred_ctr: PPC_PRED_Z
       -
         asm_text: "bclr 0x10, 4*cr1+eq, 0"
@@ -1814,4 +1817,5 @@ test_cases:
               bi_set: true
               bo: 16
               bo_set: true
+              pred_cr: PPC_PRED_INVALID
               pred_ctr: PPC_PRED_NZ


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**
  
For a BO that encodes only the counter condition, `PPC_get_branch_pred()` falls through to `PPC_get_no_hint_pred(((bi % 4) << 5) | bo)`. BI selects a CR bit and has no part in that predicate, so mixing it in lands outside `ppc_pred` and the counter test is lost:

    42 00 ff f0   BO=16 BI=0  ->  pred_ctr = PPC_PRED_NZ        correct
    42 06 00 10   BO=16 BI=6  ->  pred_ctr = PPC_PRED_INVALID   same BO

The combined-condition branch above already gets this right — it computes `(bo | PPC_BO_TEST_CR) & ~PPC_BO_CR_CMP` and notes that BI is ignored. Rather than repeat that expression, the `!get_cr_pred` case is hoisted above the `TestCR && DecrCTR` block, so the CTR predicate is derived in one place and the `ctr_bo_cond` local goes away. The function's doc comment already promises  `PPC_PRED_INVALID` only when no such predicate is encoded, so this restores the documented contract rather than changing it.

**Test plan**

One case in `tests/details/ppc.yaml` covering BO=16 and BO=18 with a non-zero BI on `bc`, plus a `bclr` for the XL form, whose BI and BO come out of a different field mask. The BO=16 BI=6 `bc` fails against unpatched `next`; the others state the invariant in the fixture rather than in one encoding.

Each case also asserts `pred_cr: PPC_PRED_INVALID`, so that deriving the CTR predicate in one place cannot start manufacturing a CR one. That needed the one-line map addition: `PPC_PRED_INVALID` was the only `ppc_pred` member missing from `cs_enum_map`, and `compare_enum_ret` is wrapped in `if (expected)`, so until the name resolves the field is silently not compared at all. It is asserted only on the new cases — a combined-condition branch legitimately has both predicates, as the existing `bdztla 4*cr5+eq` case shows.

- **Purely additive over the full `BO x BI` space** (32x32) of `bc`, `bclr` and `bcctr` — 3072 encodings: those that returned `PPC_PRED_INVALID` now return the predicate they encode, and **no existing value changes**.
- `cstest tests/` goes 87971/87034/932/5 -> 87972/87035/932/5 — the same five failures, all `tests/negative/`, and no expectation edited.
- Re-checked that the new `pred_cr` assertion does not mask the `pred_ctr` one it sits beside (a case stops at its first mismatch, and `pred_cr` is compared first): with the `ppc.h` change reverted, the case still fails on `pred_ctr`.

**Closing issues**

None
