### PR TITLE
systemz: bounds-check register index in decodeRegisterClass

### DIFF
--- a/arch/SystemZ/SystemZDisassembler.c
+++ b/arch/SystemZ/SystemZDisassembler.c
@@ -78,7 +78,7 @@ static DecodeStatus decodeRegisterClass(MCInst *Inst, uint64_t RegNo,
 					const unsigned *Regs, unsigned Size,
 					bool IsAddr)
 {
-	CS_ASSERT((RegNo < Size && "Invalid register"));
+	CS_ASSERT_RET_VAL(RegNo < Size, MCDisassembler_Fail);
 	if (IsAddr && RegNo == 0) {
 		RegNo = SystemZ_NoRegister;
 	} else {


### PR DESCRIPTION
**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

`decodeRegisterClass` in the SystemZ disassembler indexes the register table as `Regs[RegNo]`, guarding `RegNo` against the register-class size `Size` only with `CS_ASSERT`. `CS_ASSERT` expands to nothing in release builds (no `CAPSTONE_DEBUG` / `CAPSTONE_ASSERTION_WARNINGS`), so in release the index is used with no bounds check and an out-of-range `RegNo` reads past the register table before the existing `RegNo == 0` check runs.

This switches it to `CS_ASSERT_RET_VAL(RegNo < Size, MCDisassembler_Fail)`, so the check also holds in release builds and an out-of-range register index fails decoding instead of reading out of bounds. Same shape as the decoder-table bounds checks added in the recent OOB fixes (#2968). No API or struct changes, so nothing to document. Neither checklist item is ticked: no API changed, and the out-of-range path is not reachable through the public API today, so there is no disassembly regression to add.

**Test plan**

Valid encodings are unaffected: `RegNo < Size` holds for every real SystemZ encoding, so `CS_ASSERT_RET_VAL` never returns early for them and decode output is unchanged. Verified with `cstool systemz` across GR/FP/VR/AR/CR register operands and with the unit test suite (stays green). An exhaustive sweep of the 2/4/6-byte SystemZ input space never drove `RegNo` past `Size`, so this is hardening for release builds rather than a fix for a reachable crash.

**Closing issues**

None.
