### PR TITLE
AArch64: SYSL writes its Rt operand, it does not read it

### DIFF
--- a/arch/AArch64/AArch64GenCSMappingInsnOp.inc
+++ b/arch/AArch64/AArch64GenCSMappingInsnOp.inc
@@ -46762,7 +46762,7 @@
 }},
 { /* AARCH64_SYSLxt (7060) - AARCH64_INS_SYSL - sysl	$Rt, $op1, $Cn, $Cm, $op2 */
 {
-  { CS_OP_REG, CS_AC_READ, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* Rt */
+  { CS_OP_REG, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* Rt */
   { CS_OP_IMM, CS_AC_READ, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* op1 */
   { CS_OP_IMM, CS_AC_READ, { CS_DATA_TYPE_i32, CS_DATA_TYPE_LAST } }, /* Cn */
   { CS_OP_IMM, CS_AC_READ, { CS_DATA_TYPE_i32, CS_DATA_TYPE_LAST } }, /* Cm */

--- a/tests/details/aarch64.yaml
+++ b/tests/details/aarch64.yaml
@@ -1800,3 +1800,15 @@ test_cases:
               mem_disp: 1
               access: CS_AC_WRITE
           regs_read: [ b10, x8 ]
+  -
+    input:
+      bytes: [0x00,0x00,0x28,0xd5]
+      arch: "CS_ARCH_AARCH64"
+      options: [ CS_OPT_DETAIL ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "sysl	x0, #0, c0, c0, #0"
+        details:
+          regs_write: [ x0 ]


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

SYSL was generated with CS_AC_READ on Rt, but Rt is the destination. "SYSL <Xt>, #<op1>, <Cn>, <Cm>{, #<op2>}" is the system instruction WITH RESULT, and the Arm ARM names Xt "the 64-bit name of the general-purpose destination register", encoded in the Rt field.

Before:

```
  sysl x0, #0, c0, c0, #0
    operands[0].type: REG = x0
    operands[0].access: READ
  Registers read: x0
```

After:

```
  sysl x0, #0, c0, c0, #0
    operands[0].type: REG = x0
    operands[0].access: WRITE
  Registers modified: x0
```

A consumer tracking register liveness saw a use where there is a definition, which is the unsafe direction: a value written into Xt looked like it was still needed.

SYS (without the L) is the opposite direction -- its Xt is a source, and it takes it as the last operand -- and is already CS_AC_READ; it is untouched.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

Adds the correction to suite/auto-sync/inc_patches so it survives regeneration, plus a regression case. That case asserts regs_write rather than the operand list because two of SYSL's five operands are AARCH64_OP_CIMM, which cstest's operand comparison does not handle (it would take the default branch and report "op type not handled").

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->