### PR TITLE
AArch64: fix Rt operand of the integer STLUR forms

### DIFF
--- a/arch/AArch64/AArch64GenCSMappingInsnOp.inc
+++ b/arch/AArch64/AArch64GenCSMappingInsnOp.inc
@@ -44341,28 +44341,28 @@
 }},
 { /* AARCH64_STLURBi (6753) - AARCH64_INS_STLURB - stlurb	$Rt, [$Rn, $offset] */
 {
-  { CS_OP_REG | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i32, CS_DATA_TYPE_LAST } }, /* Rt */
+  { CS_OP_REG, CS_AC_READ, { CS_DATA_TYPE_i32, CS_DATA_TYPE_LAST } }, /* Rt */
   { CS_OP_REG | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* Rn */
   { CS_OP_IMM | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* offset */
   { 0 }
 }},
 { /* AARCH64_STLURHi (6754) - AARCH64_INS_STLURH - stlurh	$Rt, [$Rn, $offset] */
 {
-  { CS_OP_REG | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i32, CS_DATA_TYPE_LAST } }, /* Rt */
+  { CS_OP_REG, CS_AC_READ, { CS_DATA_TYPE_i32, CS_DATA_TYPE_LAST } }, /* Rt */
   { CS_OP_REG | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* Rn */
   { CS_OP_IMM | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* offset */
   { 0 }
 }},
 { /* AARCH64_STLURWi (6755) - AARCH64_INS_STLUR - stlur	$Rt, [$Rn, $offset] */
 {
-  { CS_OP_REG | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i32, CS_DATA_TYPE_LAST } }, /* Rt */
+  { CS_OP_REG, CS_AC_READ, { CS_DATA_TYPE_i32, CS_DATA_TYPE_LAST } }, /* Rt */
   { CS_OP_REG | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* Rn */
   { CS_OP_IMM | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* offset */
   { 0 }
 }},
 { /* AARCH64_STLURXi (6756) - AARCH64_INS_STLUR - stlur	$Rt, [$Rn, $offset] */
 {
-  { CS_OP_REG | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* Rt */
+  { CS_OP_REG, CS_AC_READ, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* Rt */
   { CS_OP_REG | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* Rn */
   { CS_OP_IMM | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* offset */
   { 0 }

--- a/suite/auto-sync/inc_patches/AArch64/02_stlur_rt_operand.patch
+++ b/suite/auto-sync/inc_patches/AArch64/02_stlur_rt_operand.patch
@@ -1,0 +1,54 @@
+# AArch64 STLURB/STLURH/STLUR (the four integer FEAT_LRCPC2 unscaled
+# store-release forms) were generated with CS_OP_MEM set on the Rt data
+# operand and CS_AC_WRITE for its access. Both are wrong: Rt is a plain
+# source register, exactly as in the STUR forms these mirror.
+#
+# The stray CS_OP_MEM made the mapping fold Rt into the memory operand,
+# so `stlur x10, [x8, #8]` decoded with the data register as mem.base,
+# the real base as mem.index, and the displacement as a second MEM
+# operand -- with no register operand at all:
+#
+#   op_count: 2
+#     operands[0].type: MEM  base: x10  index: x8   access: WRITE
+#     operands[1].type: MEM  disp: 0x8              access: WRITE
+#
+# The five SIMD&FP STLUR forms (STLURbi/di/hi/qi/si) were already
+# correct and are left alone. This patch makes the four integer forms
+# match STURBi/STURHi/STURWi/STURXi.
+diff --git a/arch/AArch64/AArch64GenCSMappingInsnOp.inc b/arch/AArch64/AArch64GenCSMappingInsnOp.inc
+index 4954eb31..1c033405 100644
+--- a/arch/AArch64/AArch64GenCSMappingInsnOp.inc
++++ b/arch/AArch64/AArch64GenCSMappingInsnOp.inc
+@@ -44341,28 +44341,28 @@
+ }},
+ { /* AARCH64_STLURBi (6753) - AARCH64_INS_STLURB - stlurb	$Rt, [$Rn, $offset] */
+ {
+-  { CS_OP_REG | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i32, CS_DATA_TYPE_LAST } }, /* Rt */
++  { CS_OP_REG, CS_AC_READ, { CS_DATA_TYPE_i32, CS_DATA_TYPE_LAST } }, /* Rt */
+   { CS_OP_REG | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* Rn */
+   { CS_OP_IMM | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* offset */
+   { 0 }
+ }},
+ { /* AARCH64_STLURHi (6754) - AARCH64_INS_STLURH - stlurh	$Rt, [$Rn, $offset] */
+ {
+-  { CS_OP_REG | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i32, CS_DATA_TYPE_LAST } }, /* Rt */
++  { CS_OP_REG, CS_AC_READ, { CS_DATA_TYPE_i32, CS_DATA_TYPE_LAST } }, /* Rt */
+   { CS_OP_REG | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* Rn */
+   { CS_OP_IMM | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* offset */
+   { 0 }
+ }},
+ { /* AARCH64_STLURWi (6755) - AARCH64_INS_STLUR - stlur	$Rt, [$Rn, $offset] */
+ {
+-  { CS_OP_REG | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i32, CS_DATA_TYPE_LAST } }, /* Rt */
++  { CS_OP_REG, CS_AC_READ, { CS_DATA_TYPE_i32, CS_DATA_TYPE_LAST } }, /* Rt */
+   { CS_OP_REG | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* Rn */
+   { CS_OP_IMM | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* offset */
+   { 0 }
+ }},
+ { /* AARCH64_STLURXi (6756) - AARCH64_INS_STLUR - stlur	$Rt, [$Rn, $offset] */
+ {
+-  { CS_OP_REG | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* Rt */
++  { CS_OP_REG, CS_AC_READ, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* Rt */
+   { CS_OP_REG | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* Rn */
+   { CS_OP_IMM | CS_OP_MEM, CS_AC_WRITE, { CS_DATA_TYPE_i64, CS_DATA_TYPE_LAST } }, /* offset */
+   { 0 }

--- a/tests/details/aarch64.yaml
+++ b/tests/details/aarch64.yaml
@@ -1685,3 +1685,118 @@ test_cases:
         details:
           # Exact-match register lists: x0/x1 only, no NZCV write.
           regs_read: [ x0, x1 ]
+  -
+    input:
+      bytes: [0x13,0x11,0x00,0x19]
+      arch: "CS_ARCH_AARCH64"
+      options: [ CS_OPT_DETAIL ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "stlurb	w19, [x8, #1]"
+        details:
+          aarch64:
+            operands:
+            -
+              type: AARCH64_OP_REG
+              reg: w19
+              access: CS_AC_READ
+            -
+              type: AARCH64_OP_MEM
+              mem_base: x8
+              mem_disp: 1
+              access: CS_AC_WRITE
+          regs_read: [ w19, x8 ]
+  -
+    input:
+      bytes: [0x13,0x21,0x00,0x59]
+      arch: "CS_ARCH_AARCH64"
+      options: [ CS_OPT_DETAIL ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "stlurh	w19, [x8, #2]"
+        details:
+          aarch64:
+            operands:
+            -
+              type: AARCH64_OP_REG
+              reg: w19
+              access: CS_AC_READ
+            -
+              type: AARCH64_OP_MEM
+              mem_base: x8
+              mem_disp: 2
+              access: CS_AC_WRITE
+          regs_read: [ w19, x8 ]
+  -
+    input:
+      bytes: [0x0a,0x41,0x00,0x99]
+      arch: "CS_ARCH_AARCH64"
+      options: [ CS_OPT_DETAIL ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "stlur	w10, [x8, #4]"
+        details:
+          aarch64:
+            operands:
+            -
+              type: AARCH64_OP_REG
+              reg: w10
+              access: CS_AC_READ
+            -
+              type: AARCH64_OP_MEM
+              mem_base: x8
+              mem_disp: 4
+              access: CS_AC_WRITE
+          regs_read: [ w10, x8 ]
+  -
+    input:
+      bytes: [0x0a,0x81,0x00,0xd9]
+      arch: "CS_ARCH_AARCH64"
+      options: [ CS_OPT_DETAIL ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "stlur	x10, [x8, #8]"
+        details:
+          aarch64:
+            operands:
+            -
+              type: AARCH64_OP_REG
+              reg: x10
+              access: CS_AC_READ
+            -
+              type: AARCH64_OP_MEM
+              mem_base: x8
+              mem_disp: 8
+              access: CS_AC_WRITE
+          regs_read: [ x10, x8 ]
+  -
+    input:
+      bytes: [0x0a,0x19,0x00,0x1d]
+      arch: "CS_ARCH_AARCH64"
+      options: [ CS_OPT_DETAIL ]
+      address: 0x0
+    expected:
+      insns:
+      -
+        asm_text: "stlur	b10, [x8, #1]"
+        details:
+          aarch64:
+            operands:
+            -
+              type: AARCH64_OP_REG
+              reg: b10
+              access: CS_AC_READ
+            -
+              type: AARCH64_OP_MEM
+              mem_base: x8
+              mem_disp: 1
+              access: CS_AC_WRITE
+          regs_read: [ b10, x8 ]


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

STLURB, STLURH and the two STLUR integer forms were generated with CS_OP_MEM set on their Rt data operand and CS_AC_WRITE for its access. Both are wrong: Rt is a plain source register, exactly as in the STUR forms these mirror.

The stray CS_OP_MEM made the mapping fold Rt into the memory operand, so the data register became mem.base, the real base became mem.index, and the displacement started a second MEM operand -- leaving the instruction with no register operand at all:

```
  stlur x10, [x8, #8]
  op_count: 2
    operands[0].type: MEM  base: x10  index: x8  access: WRITE
    operands[1].type: MEM  disp: 0x8            access: WRITE
```

against STUR's correct

```
  stur x10, [x8, #8]
  op_count: 2
    operands[0].type: REG = x10                 access: READ
    operands[1].type: MEM  base: x8  disp: 0x8  access: WRITE
```

A consumer walking the operand list therefore saw neither the value being stored nor the address it is stored to. cs_regs_access() happened to report both registers, which is why this survived: only the operand view was broken.

The five SIMD&FP STLUR forms (STLURbi/di/hi/qi/si) were already correct and are untouched; LDAPUR, the load half, was correct too.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->

Adds the correction to suite/auto-sync/inc_patches so it survives regeneration, and regression cases for all four fixed forms plus one SIMD&FP form as the unchanged control.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->