### PR TITLE
auto-sync: pin lit below 23 to unbreak CI

### DIFF
--- a/suite/auto-sync/pyproject.toml
+++ b/suite/auto-sync/pyproject.toml
@@ -15,7 +15,10 @@ dependencies = [
   "ninja >= 1.11.1.1",
   "reuse >= 3.0.1",
   "clang-format >= 18.1.1",
-  "lit >= 18.1.8",
+  # lit 23.1.0 removed the positional execute_external=True that
+  # lit_config/lit.cfg.py passes to ShTest, which fails every
+  # Auto-Sync run. Pinned below it until that call is migrated.
+  "lit >= 18.1.8, < 23",
 ]
 requires-python = ">= 3.11"
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

lit 23.1.0 was published on 2026-08-25 and made
lit.formats.ShTest(execute_external=True) raise instead of accepting it. lit_config/lit.cfg.py passes that argument positionally:

```
  config.test_format = lit.formats.ShTest(True)
```

so every Auto-Sync run since has failed at config load:

```
  ValueError: execute_external=True is deprected as of LLVM-23 and the
  option will be removed in LLVM-24. Please move to using the internal
  shell (execute_external=False). If you still need to force external
  execution to allow time for migration, set force_execute_external=True
```

The dependency was declared "lit >= 18.1.8" with no upper bound, and lit had not released since 18.1.8 in June 2024, so the first CI run after 23.1.0 landed picked it up. Every PR since fails identically, across unrelated architectures -- alpha-mem-disp-signext, x86-att-detail-bugs and two AArch64 branches all report the same error; the last green Auto-Sync run was 2026-08-24.

Pinning restores the version CI was actually testing with: `pip install --dry-run "lit >= 18.1.8, < 23"` resolves to 18.1.8, against 23.1.0 unpinned. Nothing between 18.1.8 and 23.1.0 exists on PyPI, so the bound excludes exactly the broken release.

This is the minimal unblock, not the fix. Migrating the ShTest call -- either force_execute_external=True to keep the external shell, or execute_external=False to move to lit's internal one -- wants the generated test suite run against it and belongs in its own change.

Worth noting separately: MCUpdater.run_llvm_lit creates a symlink before invoking lit and does not remove it when lit raises, so the remaining tests in the process die with FileExistsError rather than the real error. Two of the four reported failures were that cascade.
**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Disassembly tests should be added in suite/cs_test/issues.cs -->


**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
