### PR TITLE
synctools: generalize asmwriter.py's AArch64-only alias/mnemonic logic

### DIFF
--- a/suite/synctools/asmwriter.py
+++ b/suite/synctools/asmwriter.py
@@ -140,8 +140,15 @@ for line in lines:
             print_line("static void printInstruction(MCInst *MI, SStream *O)\n{")
     elif 'LLVM_NO_PROFILE_INSTRUMENT_FUNCTION' in line:
         continue
-    elif 'AArch64InstPrinter::getMnemonic' in line:
+    elif arch + 'InstPrinter::getMnemonic' in line:
         print_line("static uint64_t getMnemonic(MCInst *MI, SStream *O, unsigned int opcode) {")
+    elif 'return {nullptr, Bits};' in line:
+        # Newer LLVM adds an early-out guard ("if (Bits == 0) return {NULL,
+        # Bits};") before the real return in getMnemonic, for opcodes with
+        # no recognized mnemonic pattern at all. Nothing to print in that
+        # case - just propagate the (0) Bits value, matching the folded
+        # uint64_t-returning signature used elsewhere in this conversion.
+        print_line("\t\treturn Bits;")
     elif 'return {AsmStrs+(Bits' in line:
         tmp = line.split(',')
         prntStr = tmp[0].split('{')[1]
@@ -153,13 +160,20 @@ for line in lines:
         continue
     elif 'uint64_t Bits = MnemonicInfo' in line:
         print_line("\tuint64_t Bits = getMnemonic(MI, O, opcode);")
-    elif 'const char *AArch64InstPrinter::' in line:
+    elif 'const char *' + arch + 'InstPrinter::' in line and 'getRegisterName' not in line:
         continue
     elif 'getRegisterName(' in line:
         if 'unsigned AltIdx' in line:
             print_line("static const char *getRegisterName(unsigned RegNo, unsigned AltIdx)\n{")
         else:
             print_line("static const char *getRegisterName(unsigned RegNo)\n{")
+    elif 'RegNo = Reg.id();' in line:
+        # Newer LLVM wraps register handles in MCRegister, so the raw
+        # definition reads `getRegisterName(MCRegister Reg) { unsigned RegNo
+        # = Reg.id(); ... }`. Our hardcoded signature above already declares
+        # RegNo directly as a plain unsigned parameter, so this becomes a
+        # redundant (and illegal, redeclaring the parameter) redefinition.
+        continue
     elif 'getRegisterName' in line:
         in_getRegisterName = True
         print_line(line)
@@ -668,7 +682,7 @@ for line in lines:
         line = line.replace(')', '')
         print_line(line)
     elif '#ifndef NDEBUG' in line and in_printAliasInstr:
-        print_line("""
+        alias_match_block = """
   char *AsmString;
   const size_t OpToSize = sizeof(OpToPatterns) / sizeof(PatternsForOpcode);
 
@@ -802,7 +816,47 @@ for line in lines:
   cs_mem_free(AsmString);
   return tmpString;
 }
-        """)
+        """
+        # AArch64InstPrinterValidateMCOperand was hardcoded here for AArch64
+        # (the only arch this injected block was ever written for). Only
+        # called when a K_Custom AliasPatternCond exists for this target -
+        # a real function of this exact name is then emitted directly into
+        # this same .inc file by llvm-tblgen; if the target has no K_Custom
+        # conditions (as of writing, true for PPC), the target's
+        # InstPrinter.c must provide a small stub of this name so the
+        # (unreachable) call site still compiles.
+        alias_match_block = alias_match_block.replace(
+            'AArch64InstPrinterValidateMCOperand', arch + 'InstPrinterValidateMCOperand')
+        # set_sme_index()/isSME distinguish AArch64 SME tile-slice indexing
+        # brackets (e.g. "za[w8, 0]") from ordinary memory-operand brackets;
+        # set_sme_index() only exists in AArch64InstPrinter.c. No other
+        # target has SME syntax, so every '[' / ']' there is always the
+        # ordinary memory-operand case.
+        if arch.upper() not in ('AARCH64', 'ARM64'):
+            alias_match_block = alias_match_block.replace(
+                "    bool isSME = false;\n    do {", "    do {")
+            alias_match_block = alias_match_block.replace(
+                """        if (AsmString[I] == '[') {
+          if (AsmString[I-1] != ' ') {
+            set_sme_index(MI, true);
+            isSME = true;
+          } else {
+            set_mem_access(MI, true);
+          }
+        } else if (AsmString[I] == ']') {
+          if (isSME) {
+            set_sme_index(MI, false);
+            isSME = false;
+          } else {
+            set_mem_access(MI, false);
+          }
+        }""",
+                """        if (AsmString[I] == '[') {
+          set_mem_access(MI, true);
+        } else if (AsmString[I] == ']') {
+          set_mem_access(MI, false);
+        }""")
+        print_line(alias_match_block)
         in_printAliasInstr = False
         # skip next few lines
         skip_printing = True


### PR DESCRIPTION
## Problem

`suite/synctools/asmwriter.py` (the script that converts raw `llvm-tblgen -gen-asm-writer` output into capstone's C style) has AArch64-only logic hardcoded into several places, dating to when the script was written for AArch64 in 2022 and never exercised against another target since. Running it against a non-AArch64 target's raw tblgen output produced by a reasonably modern LLVM breaks in several ways - found while regenerating PowerPC's asm-writer output for #3052.

## Bugs fixed

- `getRegisterName`/`getMnemonic`'s `"const char *AArch64InstPrinter::"` skip rule was a literal string match, so for any other target it also matched (and silently swallowed) that target's own real `getRegisterName` definition line - e.g. PPC's `"const char *PPCInstPrinter::getRegisterName(...)"` matches the same substring pattern. Result: a `getRegisterName` body with no function signature at all. Now excludes `getRegisterName` explicitly, and matches the target's own class name instead of a hardcoded `AArch64InstPrinter`.
- `getMnemonic` had no translation for newer LLVM's early-out guard (`if (Bits == 0) return {nullptr, Bits};`), which doesn't exist in the older LLVM output this script was originally written against.
- Newer LLVM wraps register handles in `MCRegister`, so `getRegisterName`'s raw definition now includes a `RegNo = Reg.id();` redeclaration line that conflicts with this script's hardcoded plain-`unsigned`-parameter signature.
- The injected `printAliasInstr` alias-matching block hardcoded `AArch64InstPrinterValidateMCOperand` and AArch64's SME tile-slice-indexing bracket syntax (`za[w8, 0]`) unconditionally. Validator name is now parameterized by target; SME bracket handling now only applies for AArch64/ARM64, with a plain `set_mem_access()`-only fallback for every other target (none of which have SME syntax).

Each fix was confirmed necessary by an actual compiler/parse error while iterating toward a from-scratch PPC rebuild, not speculative.

## Scope note

This is a synctools script fix, not a PPC-specific change - it generalizes logic that only worked for AArch64 to work for any target regenerated against a comparably modern LLVM. It's independent of #3052, which uses an older (LLVM 7.0.1-vintage) toolchain that doesn't hit any of these code paths at all.

One related note for anyone regenerating a target against modern LLVM specifically: if that target has zero `K_Custom` `AliasPatternCond`s (true for PPC, as of writing), the injected `<Target>InstPrinterValidateMCOperand` call in the alias-matching block is unreachable but still needs a stub of that name in the target's `InstPrinter.c` to link - this script doesn't generate that stub itself, since it's C source, not template output.
