### PR TITLE
Java: Fix incorrect size of `regs_read` array in Java binding

### DIFF
--- a/bindings/java/capstone/Capstone.java
+++ b/bindings/java/capstone/Capstone.java
@@ -78,7 +78,7 @@ public class Capstone {
     public static class ByReference extends _cs_detail implements Structure.ByReference {};
 
     // list of all implicit registers being read.
-    public short[] regs_read = new short[16];
+    public short[] regs_read = new short[20];
     public byte regs_read_count;
     // list of all implicit registers being written.
     public short[] regs_write = new short[20];


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

Fixes the Java binding which is currently completely broken. See: #3054

...

**Test plan**

Use the Java binding to disassemble x86 opcodes

...

**Closing issues**

closes #3054


...
