### PR TITLE
Fix incorrect array sizes in Java binding: `regs_read` and `regs_write`

### DIFF
--- a/bindings/java/capstone/Capstone.java
+++ b/bindings/java/capstone/Capstone.java
@@ -78,10 +78,10 @@ public class Capstone {
     public static class ByReference extends _cs_detail implements Structure.ByReference {};
 
     // list of all implicit registers being read.
-    public short[] regs_read = new short[16];
+    public short[] regs_read = new short[20];
     public byte regs_read_count;
     // list of all implicit registers being written.
-    public short[] regs_write = new short[20];
+    public short[] regs_write = new short[47];
     public byte regs_write_count;
     // list of semantic groups this instruction belongs to.
     public byte[] groups = new byte[16];


### PR DESCRIPTION
**Your checklist for this pull request**
- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

See this issue for the 5 release: #3054

...

**Test plan**

Leverage the Java binding and disassemble x86 opcodes

...

**Closing issues**

N/A

...
