### PR TITLE
X86: Zero the operand slot before filling it in the Intel implicit insert

### DIFF
--- a/arch/X86/X86IntelInstPrinter.c
+++ b/arch/X86/X86IntelInstPrinter.c
@@ -810,6 +810,8 @@ void X86_Intel_printInst(MCInst *MI, SStream *O, void *Info)
 					(ARR_SIZE(MI->flat_insn->detail->x86
 							  .operands) -
 					 1));
+			memset(&(MI->flat_insn->detail->x86.operands[0]), 0,
+			       sizeof(MI->flat_insn->detail->x86.operands[0]));
 			MI->flat_insn->detail->x86.operands[0].type =
 				X86_OP_REG;
 			MI->flat_insn->detail->x86.operands[0].reg = reg;


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

The Intel printer's implicit-register insert leaves the inactive union members of `operands[0]` holding the shifted-away operand's bytes — the same defect #3042 fixed in the AT&T printer. For `mov al, byte ptr [0x8070605040302010]`
(`a0 10 20 30 40 50 60 70 80`, 64-bit, `CS_OPT_DETAIL`):

```c
cs_x86_op *op = &insn->detail->x86.operands[0];
printf("%s disp=0x%" PRIx64 "\n", cs_reg_name(h, op->reg), op->mem.disp);
// al disp=0x8070605040302010   <- the stale memory operand, behind X86_OP_REG
// with this fix: al disp=0x0
```

- One `memset` after the `memmove`, mirroring `41953823` exactly.
- The `X86_insn_reg_intel2` path shifts nothing into a dirty slot, so it is unchanged — same as on the AT&T side.

**Test plan**

As with the AT&T memset, the stale bytes are inactive union members, which cstest's type-gated comparison can'tt reach — no yaml case is possible. 

**Closing issues**

None.