### PR TITLE
cstest: Compare the PPC branch details once and without requiring operands

### DIFF
--- a/suite/cstest/src/test_detail_ppc.c
+++ b/suite/cstest/src/test_detail_ppc.c
@@ -123,11 +123,11 @@ bool test_expected_ppc(csh *handle, const cs_ppc *actual,
 	compare_enum_ret(actual->format, expected->format, false);
 	compare_tbool_ret(actual->update_cr0, expected->update_cr0, false);
 
-	if (expected->operands_count == 0) {
-		return true;
+	if (expected->operands_count != 0) {
+		compare_uint8_ret(actual->op_count, expected->operands_count,
+				  false);
 	}
-	compare_uint8_ret(actual->op_count, expected->operands_count, false);
-	for (size_t i = 0; i < actual->op_count; ++i) {
+	for (size_t i = 0; i < expected->operands_count; ++i) {
 		const cs_ppc_op *op = &actual->operands[i];
 		TestDetailPPCOp *eop = expected->operands[i];
 		compare_enum_ret(op->type, eop->type, false);
@@ -135,7 +135,7 @@ bool test_expected_ppc(csh *handle, const cs_ppc *actual,
 		switch (op->type) {
 		default:
 			fprintf(stderr,
-				"arm op type %" PRId32 " not handled.\n",
+				"ppc op type %" PRId32 " not handled.\n",
 				op->type);
 			return false;
 		case PPC_OP_REG:
@@ -152,33 +152,31 @@ bool test_expected_ppc(csh *handle, const cs_ppc *actual,
 			compare_int_ret(op->mem.disp, eop->mem_disp, false);
 			break;
 		}
+	}
 
-		if (expected->bc) {
-			if (expected->bc->bi_set) {
-				compare_uint8_ret(actual->bc.bi,
-						  expected->bc->bi, false);
-			} else {
-				assert(expected->bc->bi == 0);
-			}
-			if (expected->bc->bo_set) {
-				compare_uint8_ret(actual->bc.bo,
-						  expected->bc->bo, false);
-			} else {
-				assert(expected->bc->bo == 0);
-			}
-			compare_enum_ret(actual->bc.bh, expected->bc->bh,
-					 false);
-			compare_reg_ret(*handle, actual->bc.crX,
-					expected->bc->crX, false);
-			compare_enum_ret(actual->bc.crX_bit,
-					 expected->bc->crX_bit, false);
-			compare_enum_ret(actual->bc.hint, expected->bc->hint,
-					 false);
-			compare_enum_ret(actual->bc.pred_cr,
-					 expected->bc->pred_cr, false);
-			compare_enum_ret(actual->bc.pred_ctr,
-					 expected->bc->pred_ctr, false);
+	if (expected->bc) {
+		if (expected->bc->bi_set) {
+			compare_uint8_ret(actual->bc.bi, expected->bc->bi,
+					  false);
+		} else {
+			assert(expected->bc->bi == 0);
 		}
+		if (expected->bc->bo_set) {
+			compare_uint8_ret(actual->bc.bo, expected->bc->bo,
+					  false);
+		} else {
+			assert(expected->bc->bo == 0);
+		}
+		compare_enum_ret(actual->bc.bh, expected->bc->bh, false);
+		compare_reg_ret(*handle, actual->bc.crX, expected->bc->crX,
+				false);
+		compare_enum_ret(actual->bc.crX_bit, expected->bc->crX_bit,
+				 false);
+		compare_enum_ret(actual->bc.hint, expected->bc->hint, false);
+		compare_enum_ret(actual->bc.pred_cr, expected->bc->pred_cr,
+				 false);
+		compare_enum_ret(actual->bc.pred_ctr, expected->bc->pred_ctr,
+				 false);
 	}
 
 	return true;

--- a/tests/details/ppc.yaml
+++ b/tests/details/ppc.yaml
@@ -1845,3 +1845,28 @@ test_cases:
                 type: PPC_OP_REG
                 reg: cr1
                 access: CS_AC_WRITE
+  -
+    input:
+      # Deliberately no operands: — the branch block must be compared even
+      # when the case asserts nothing about the operand list.
+      bytes: [ 0x4c, 0x16, 0x00, 0x20 ]
+      arch: "ppc"
+      options: [ CS_MODE_BIG_ENDIAN, CS_OPT_DETAIL ]
+      address: 0x1000
+    expected:
+      insns:
+      -
+        asm_text: "bdnzflr 4*cr5+eq"
+        details:
+          ppc:
+            bc:
+              bi: 22
+              bi_set: true
+              bo: 0
+              bo_set: true
+              bh: PPC_BH_SUBROUTINE_RET
+              crX: cr5
+              crX_bit: PPC_BI_Z
+              pred_cr: PPC_PRED_NE
+              pred_ctr: PPC_PRED_NZ
+              hint: PPC_BR_NOT_GIVEN


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

A ppc test case that supplies `bc:` expectations but no `operands:` passes without comparing anything. `tests/details/ppc.yaml` already has one (`bdnzlrl+`): change any of its `bc:` values to garbage —

```yaml
             bo: 99            # was 25
```

and `cstest tests/details/ppc.yaml` still reports all tests succeeded.

- `test_expected_ppc` returned early when `expected->operands_count == 0`, and the whole `expected->bc` block sat inside the operand loop so branch details were compared once per operand, or not at all for an operand-less case. The block is hoisted out of the loop and the early return replaced with a guard around the operand comparison only.
- The operand loop now iterates `expected->operands_count` rather than `actual->op_count`: with the early return gone, the old bound would dereference a NULL `expected->operands[i]` for an operand-less case.

**Test plan**

One new case: `bdnzflr 4*cr5+eq` (`4c 16 00 20`) with a full `bc:` block and deliberately no `operands:`. Any wrong value in it (or in the existing `bdnzlrl+` case) passes on unpatched `next` and fails with this fix.

The other arch comparers don't have this shape: only ppc keeps an instruction-wide block inside its operand loop; the aarch64/arm/sparc/x86 early returns skip operand comparisons only.

**Closing issues**

None.